### PR TITLE
Don't use hardcoded urls to mockserver in unittests.

### DIFF
--- a/test/test_services/test_admin.py
+++ b/test/test_services/test_admin.py
@@ -19,14 +19,14 @@ class TestAdmin(BaseTest):
 
         self.assertIsNotNone(data)
         #self.AssertEqual()
-        self.mock_http.get.assert_called_once_with('http://localhost:5000/admin/account', headers={'X-Idfy-SDK': 'Python {}'.format(version), 'Authorization': 'Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJmb28iOiJiYXIifQ.UIZchxQD36xuhacrJF9HQ5SIUxH5HBiv9noESAacsxU', 'Content-Type': 'application/json'}, params=None)
+        self.mock_http.get.assert_called_once_with('{}/admin/account'.format(self.base_url), headers={'X-Idfy-SDK': 'Python {}'.format(version), 'Authorization': 'Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJmb28iOiJiYXIifQ.UIZchxQD36xuhacrJF9HQ5SIUxH5HBiv9noESAacsxU', 'Content-Type': 'application/json'}, params=None)
 
     def test_update_account(self):
         data = self.admin_service.update_account(account_update_options=self.params)
 
         self.assertIsNotNone(data)
         #self.AssertEqual()
-        self.mock_http.put.assert_called_once_with('http://localhost:5000/admin/account', data='{"unit": "test"}', headers={'X-Idfy-SDK': 'Python {}'.format(version), 'Authorization': 'Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJmb28iOiJiYXIifQ.UIZchxQD36xuhacrJF9HQ5SIUxH5HBiv9noESAacsxU', 'Content-Type': 'application/json'}, params=None)
+        self.mock_http.put.assert_called_once_with('{}/admin/account'.format(self.base_url), data='{"unit": "test"}', headers={'X-Idfy-SDK': 'Python {}'.format(version), 'Authorization': 'Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJmb28iOiJiYXIifQ.UIZchxQD36xuhacrJF9HQ5SIUxH5HBiv9noESAacsxU', 'Content-Type': 'application/json'}, params=None)
         
     @unittest.skip("Mock server error")
     def test_create_account(self):
@@ -49,7 +49,7 @@ class TestAdmin(BaseTest):
 
         self.assertIsNotNone(data)
         #self.AssertEqual()
-        self.mock_http.get.assert_called_once_with('http://localhost:5000/admin/account/list', headers={'X-Idfy-SDK': 'Python {}'.format(version), 'Authorization': 'Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJmb28iOiJiYXIifQ.UIZchxQD36xuhacrJF9HQ5SIUxH5HBiv9noESAacsxU', 'Content-Type': 'application/json'}, params={'name': None, 'orgNo': None, 'uniCustomerNo': None, 'createdBefore': None, 'createdAfter': None, 'lastModifiedBefore': None,
+        self.mock_http.get.assert_called_once_with('{}/admin/account/list'.format(self.base_url), headers={'X-Idfy-SDK': 'Python {}'.format(version), 'Authorization': 'Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJmb28iOiJiYXIifQ.UIZchxQD36xuhacrJF9HQ5SIUxH5HBiv9noESAacsxU', 'Content-Type': 'application/json'}, params={'name': None, 'orgNo': None, 'uniCustomerNo': None, 'createdBefore': None, 'createdAfter': None, 'lastModifiedBefore': None,
 'lastModifiedAfter': None, 'dealerName': None, 'dealerReference': None, 'tags': None, 'enable': None})
 
     def test_list_account_names(self):
@@ -57,70 +57,70 @@ class TestAdmin(BaseTest):
 
         self.assertIsNotNone(data)
         #self.AssertEqual()
-        self.mock_http.get.assert_called_once_with('http://localhost:5000/admin/account/list/names', headers={'X-Idfy-SDK': 'Python {}'.format(version), 'Authorization': 'Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJmb28iOiJiYXIifQ.UIZchxQD36xuhacrJF9HQ5SIUxH5HBiv9noESAacsxU', 'Content-Type': 'application/json'}, params=None)
+        self.mock_http.get.assert_called_once_with('{}/admin/account/list/names'.format(self.base_url), headers={'X-Idfy-SDK': 'Python {}'.format(version), 'Authorization': 'Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJmb28iOiJiYXIifQ.UIZchxQD36xuhacrJF9HQ5SIUxH5HBiv9noESAacsxU', 'Content-Type': 'application/json'}, params=None)
 
     def test_get_dealer(self):
         data = self.admin_service.get_dealer(dealer_id="1")
 
         self.assertIsNotNone(data)
         #self.AssertEqual()
-        self.mock_http.get.assert_called_once_with('http://localhost:5000/admin/dealer/1', headers={'X-Idfy-SDK': 'Python {}'.format(version), 'Authorization': 'Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJmb28iOiJiYXIifQ.UIZchxQD36xuhacrJF9HQ5SIUxH5HBiv9noESAacsxU', 'Content-Type': 'application/json'}, params=None)
+        self.mock_http.get.assert_called_once_with('{}/admin/dealer/1'.format(self.base_url), headers={'X-Idfy-SDK': 'Python {}'.format(version), 'Authorization': 'Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJmb28iOiJiYXIifQ.UIZchxQD36xuhacrJF9HQ5SIUxH5HBiv9noESAacsxU', 'Content-Type': 'application/json'}, params=None)
 
     def test_update_dealer(self):
         data = self.admin_service.update_dealer(dealer_id="1", dealer=self.params)
 
         self.assertIsNotNone(data)
         #self.AssertEqual()
-        self.mock_http.post.assert_called_once_with('http://localhost:5000/admin/dealer/1', auth=None, data='{"unit": "test"}', headers={'X-Idfy-SDK': 'Python {}'.format(version), 'Authorization': 'Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJmb28iOiJiYXIifQ.UIZchxQD36xuhacrJF9HQ5SIUxH5HBiv9noESAacsxU', 'Content-Type': 'application/json'}, params=None)
+        self.mock_http.post.assert_called_once_with('{}/admin/dealer/1'.format(self.base_url), auth=None, data='{"unit": "test"}', headers={'X-Idfy-SDK': 'Python {}'.format(version), 'Authorization': 'Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJmb28iOiJiYXIifQ.UIZchxQD36xuhacrJF9HQ5SIUxH5HBiv9noESAacsxU', 'Content-Type': 'application/json'}, params=None)
 
     def test_list_accounts_for_dealer(self):
         data = self.admin_service.list_accounts_for_dealer(dealer_id="1")
 
         self.assertIsNotNone(data)
         #self.AssertEqual()
-        self.mock_http.get.assert_called_once_with('http://localhost:5000/admin/dealer/1/accounts', headers={'X-Idfy-SDK': 'Python {}'.format(version), 'Authorization': 'Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJmb28iOiJiYXIifQ.UIZchxQD36xuhacrJF9HQ5SIUxH5HBiv9noESAacsxU', 'Content-Type': 'application/json'}, params=None)
+        self.mock_http.get.assert_called_once_with('{}/admin/dealer/1/accounts'.format(self.base_url), headers={'X-Idfy-SDK': 'Python {}'.format(version), 'Authorization': 'Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJmb28iOiJiYXIifQ.UIZchxQD36xuhacrJF9HQ5SIUxH5HBiv9noESAacsxU', 'Content-Type': 'application/json'}, params=None)
 
     def test_list_transactions(self):
         data = self.admin_service.list_transactions()
 
         self.assertIsNotNone(data)
         #self.AssertEqual()
-        self.mock_http.get.assert_called_once_with('http://localhost:5000/admin/invoice', headers={'X-Idfy-SDK': 'Python {}'.format(version), 'Authorization': 'Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJmb28iOiJiYXIifQ.UIZchxQD36xuhacrJF9HQ5SIUxH5HBiv9noESAacsxU', 'Content-Type': 'application/json'}, params={'year': None, 'month': None, 'get_as_csv': None})
+        self.mock_http.get.assert_called_once_with('{}/admin/invoice'.format(self.base_url), headers={'X-Idfy-SDK': 'Python {}'.format(version), 'Authorization': 'Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJmb28iOiJiYXIifQ.UIZchxQD36xuhacrJF9HQ5SIUxH5HBiv9noESAacsxU', 'Content-Type': 'application/json'}, params={'year': None, 'month': None, 'get_as_csv': None})
 
     def test_list_templates(self):
         data = self.admin_service.list_templates()
 
         self.assertIsNotNone(data)
         #self.AssertEqual()
-        self.mock_http.get.assert_called_once_with('http://localhost:5000/admin/template', headers={'X-Idfy-SDK': 'Python {}'.format(version), 'Authorization': 'Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJmb28iOiJiYXIifQ.UIZchxQD36xuhacrJF9HQ5SIUxH5HBiv9noESAacsxU', 'Content-Type': 'application/json'}, params=None)
+        self.mock_http.get.assert_called_once_with('{}/admin/template'.format(self.base_url), headers={'X-Idfy-SDK': 'Python {}'.format(version), 'Authorization': 'Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJmb28iOiJiYXIifQ.UIZchxQD36xuhacrJF9HQ5SIUxH5HBiv9noESAacsxU', 'Content-Type': 'application/json'}, params=None)
 
     def test_create_template(self):
         data = self.admin_service.create_template(pdf_template_options=self.params)
 
         self.assertIsNotNone(data)
         #self.AssertEqual()
-        self.mock_http.post.assert_called_once_with('http://localhost:5000/admin/template', auth=None, data='{"unit": "test"}', headers={'X-Idfy-SDK': 'Python {}'.format(version), 'Authorization': 'Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJmb28iOiJiYXIifQ.UIZchxQD36xuhacrJF9HQ5SIUxH5HBiv9noESAacsxU', 'Content-Type': 'application/json'}, params=None)
+        self.mock_http.post.assert_called_once_with('{}/admin/template'.format(self.base_url), auth=None, data='{"unit": "test"}', headers={'X-Idfy-SDK': 'Python {}'.format(version), 'Authorization': 'Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJmb28iOiJiYXIifQ.UIZchxQD36xuhacrJF9HQ5SIUxH5HBiv9noESAacsxU', 'Content-Type': 'application/json'}, params=None)
 
     def test_get_template(self):
         data = self.admin_service.get_template(id="1")
 
         self.assertIsNotNone(data)
         #self.AssertEqual()
-        self.mock_http.get.assert_called_once_with('http://localhost:5000/admin/template/1', headers={'X-Idfy-SDK': 'Python {}'.format(version), 'Authorization': 'Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJmb28iOiJiYXIifQ.UIZchxQD36xuhacrJF9HQ5SIUxH5HBiv9noESAacsxU', 'Content-Type': 'application/json'}, params=None)
+        self.mock_http.get.assert_called_once_with('{}/admin/template/1'.format(self.base_url), headers={'X-Idfy-SDK': 'Python {}'.format(version), 'Authorization': 'Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJmb28iOiJiYXIifQ.UIZchxQD36xuhacrJF9HQ5SIUxH5HBiv9noESAacsxU', 'Content-Type': 'application/json'}, params=None)
 
     def test_update_template(self):
         data = self.admin_service.update_template(id="1", pdf_template_options=self.params)
 
         self.assertIsNotNone(data)
         #self.AssertEqual()
-        self.mock_http.put.assert_called_once_with('http://localhost:5000/admin/template/1', data='{"unit": "test"}', headers={'X-Idfy-SDK': 'Python {}'.format(version), 'Authorization': 'Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJmb28iOiJiYXIifQ.UIZchxQD36xuhacrJF9HQ5SIUxH5HBiv9noESAacsxU', 'Content-Type': 'application/json'}, params=None)
+        self.mock_http.put.assert_called_once_with('{}/admin/template/1'.format(self.base_url), data='{"unit": "test"}', headers={'X-Idfy-SDK': 'Python {}'.format(version), 'Authorization': 'Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJmb28iOiJiYXIifQ.UIZchxQD36xuhacrJF9HQ5SIUxH5HBiv9noESAacsxU', 'Content-Type': 'application/json'}, params=None)
 
     def test_delete_template(self):
         data = self.admin_service.delete_template(id="1")
 
         self.assertIsNone(data)
         #self.AssertEqual()
-        self.mock_http.delete.assert_called_once_with('http://localhost:5000/admin/template/1', headers={'X-Idfy-SDK': 'Python {}'.format(version), 'Authorization': 'Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJmb28iOiJiYXIifQ.UIZchxQD36xuhacrJF9HQ5SIUxH5HBiv9noESAacsxU', 'Content-Type': 'application/json'})
+        self.mock_http.delete.assert_called_once_with('{}/admin/template/1'.format(self.base_url), headers={'X-Idfy-SDK': 'Python {}'.format(version), 'Authorization': 'Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJmb28iOiJiYXIifQ.UIZchxQD36xuhacrJF9HQ5SIUxH5HBiv9noESAacsxU', 'Content-Type': 'application/json'})
 
 class TestAdminAsync(BaseTest):
     @classmethod
@@ -143,7 +143,7 @@ class TestAdminAsync(BaseTest):
         
         self.assertIsNotNone(data)
         #self.AssertEqual()
-        self.mock_http.get.assert_called_once_with('http://localhost:5000/admin/account', headers={'X-Idfy-SDK': 'Python {}'.format(version), 'Authorization': 'Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJmb28iOiJiYXIifQ.UIZchxQD36xuhacrJF9HQ5SIUxH5HBiv9noESAacsxU', 'Content-Type': 'application/json'}, params=None)
+        self.mock_http.get.assert_called_once_with('{}/admin/account'.format(self.base_url), headers={'X-Idfy-SDK': 'Python {}'.format(version), 'Authorization': 'Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJmb28iOiJiYXIifQ.UIZchxQD36xuhacrJF9HQ5SIUxH5HBiv9noESAacsxU', 'Content-Type': 'application/json'}, params=None)
     
 
     def test_update_account_async(self):
@@ -153,7 +153,7 @@ class TestAdminAsync(BaseTest):
      
         self.assertIsNotNone(data)
         #self.AssertEqual()
-        self.mock_http.put.assert_called_once_with('http://localhost:5000/admin/account', data='{"unit": "test"}', headers={'X-Idfy-SDK': 'Python {}'.format(version), 'Authorization': 'Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJmb28iOiJiYXIifQ.UIZchxQD36xuhacrJF9HQ5SIUxH5HBiv9noESAacsxU', 'Content-Type': 'application/json'}, params=None)
+        self.mock_http.put.assert_called_once_with('{}/admin/account'.format(self.base_url), data='{"unit": "test"}', headers={'X-Idfy-SDK': 'Python {}'.format(version), 'Authorization': 'Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJmb28iOiJiYXIifQ.UIZchxQD36xuhacrJF9HQ5SIUxH5HBiv9noESAacsxU', 'Content-Type': 'application/json'}, params=None)
         
     @unittest.skip("Mock server error")
     def test_create_account_async(self):
@@ -180,7 +180,7 @@ class TestAdminAsync(BaseTest):
 
         self.assertIsNotNone(data)
         #self.AssertEqual()
-        self.mock_http.get.assert_called_once_with('http://localhost:5000/admin/account/list', headers={'X-Idfy-SDK': 'Python {}'.format(version), 'Authorization': 'Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJmb28iOiJiYXIifQ.UIZchxQD36xuhacrJF9HQ5SIUxH5HBiv9noESAacsxU', 'Content-Type': 'application/json'}, params={'name': None, 'orgNo': None, 'uniCustomerNo': None, 'createdBefore': None, 'createdAfter': None, 'lastModifiedBefore': None,
+        self.mock_http.get.assert_called_once_with('{}/admin/account/list'.format(self.base_url), headers={'X-Idfy-SDK': 'Python {}'.format(version), 'Authorization': 'Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJmb28iOiJiYXIifQ.UIZchxQD36xuhacrJF9HQ5SIUxH5HBiv9noESAacsxU', 'Content-Type': 'application/json'}, params={'name': None, 'orgNo': None, 'uniCustomerNo': None, 'createdBefore': None, 'createdAfter': None, 'lastModifiedBefore': None,
 'lastModifiedAfter': None, 'dealerName': None, 'dealerReference': None, 'tags': None, 'enable': None})
 
     
@@ -191,7 +191,7 @@ class TestAdminAsync(BaseTest):
 
         self.assertIsNotNone(data)
         #self.AssertEqual()
-        self.mock_http.get.assert_called_once_with('http://localhost:5000/admin/account/list/names', headers={'X-Idfy-SDK': 'Python {}'.format(version), 'Authorization': 'Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJmb28iOiJiYXIifQ.UIZchxQD36xuhacrJF9HQ5SIUxH5HBiv9noESAacsxU', 'Content-Type': 'application/json'}, params=None)
+        self.mock_http.get.assert_called_once_with('{}/admin/account/list/names'.format(self.base_url), headers={'X-Idfy-SDK': 'Python {}'.format(version), 'Authorization': 'Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJmb28iOiJiYXIifQ.UIZchxQD36xuhacrJF9HQ5SIUxH5HBiv9noESAacsxU', 'Content-Type': 'application/json'}, params=None)
 
     
     def test_get_dealer_async(self):
@@ -201,7 +201,7 @@ class TestAdminAsync(BaseTest):
 
         self.assertIsNotNone(data)
         #self.AssertEqual()
-        self.mock_http.get.assert_called_once_with('http://localhost:5000/admin/dealer/1', headers={'X-Idfy-SDK': 'Python {}'.format(version), 'Authorization': 'Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJmb28iOiJiYXIifQ.UIZchxQD36xuhacrJF9HQ5SIUxH5HBiv9noESAacsxU', 'Content-Type': 'application/json'}, params=None)
+        self.mock_http.get.assert_called_once_with('{}/admin/dealer/1'.format(self.base_url), headers={'X-Idfy-SDK': 'Python {}'.format(version), 'Authorization': 'Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJmb28iOiJiYXIifQ.UIZchxQD36xuhacrJF9HQ5SIUxH5HBiv9noESAacsxU', 'Content-Type': 'application/json'}, params=None)
 
 
     def test_update_dealer_async(self):
@@ -211,7 +211,7 @@ class TestAdminAsync(BaseTest):
 
         self.assertIsNotNone(data)
         #self.AssertEqual()
-        self.mock_http.post.assert_called_once_with('http://localhost:5000/admin/dealer/1', auth=None, data='{"unit": "test"}', headers={'X-Idfy-SDK': 'Python {}'.format(version), 'Authorization': 'Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJmb28iOiJiYXIifQ.UIZchxQD36xuhacrJF9HQ5SIUxH5HBiv9noESAacsxU', 'Content-Type': 'application/json'}, params=None)
+        self.mock_http.post.assert_called_once_with('{}/admin/dealer/1'.format(self.base_url), auth=None, data='{"unit": "test"}', headers={'X-Idfy-SDK': 'Python {}'.format(version), 'Authorization': 'Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJmb28iOiJiYXIifQ.UIZchxQD36xuhacrJF9HQ5SIUxH5HBiv9noESAacsxU', 'Content-Type': 'application/json'}, params=None)
 
 
     def test_list_accounts_for_dealer_async(self):
@@ -221,7 +221,7 @@ class TestAdminAsync(BaseTest):
 
         self.assertIsNotNone(data)
         #self.AssertEqual()
-        self.mock_http.get.assert_called_once_with('http://localhost:5000/admin/dealer/1/accounts', headers={'X-Idfy-SDK': 'Python {}'.format(version), 'Authorization': 'Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJmb28iOiJiYXIifQ.UIZchxQD36xuhacrJF9HQ5SIUxH5HBiv9noESAacsxU', 'Content-Type': 'application/json'}, params=None)
+        self.mock_http.get.assert_called_once_with('{}/admin/dealer/1/accounts'.format(self.base_url), headers={'X-Idfy-SDK': 'Python {}'.format(version), 'Authorization': 'Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJmb28iOiJiYXIifQ.UIZchxQD36xuhacrJF9HQ5SIUxH5HBiv9noESAacsxU', 'Content-Type': 'application/json'}, params=None)
             
     def test_list_transactions_async(self):
         async def func():
@@ -230,7 +230,7 @@ class TestAdminAsync(BaseTest):
 
         self.assertIsNotNone(data)
         #self.AssertEqual()
-        self.mock_http.get.assert_called_once_with('http://localhost:5000/admin/invoice', headers={'X-Idfy-SDK': 'Python {}'.format(version), 'Authorization': 'Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJmb28iOiJiYXIifQ.UIZchxQD36xuhacrJF9HQ5SIUxH5HBiv9noESAacsxU', 'Content-Type': 'application/json'}, params={'year': None, 'month': None, 'get_as_csv': None})
+        self.mock_http.get.assert_called_once_with('{}/admin/invoice'.format(self.base_url), headers={'X-Idfy-SDK': 'Python {}'.format(version), 'Authorization': 'Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJmb28iOiJiYXIifQ.UIZchxQD36xuhacrJF9HQ5SIUxH5HBiv9noESAacsxU', 'Content-Type': 'application/json'}, params={'year': None, 'month': None, 'get_as_csv': None})
 
         
     def test_list_templates_async(self):
@@ -240,7 +240,7 @@ class TestAdminAsync(BaseTest):
         
         self.assertIsNotNone(data)
         #self.AssertEqual()
-        self.mock_http.get.assert_called_once_with('http://localhost:5000/admin/template', headers={'X-Idfy-SDK': 'Python {}'.format(version), 'Authorization': 'Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJmb28iOiJiYXIifQ.UIZchxQD36xuhacrJF9HQ5SIUxH5HBiv9noESAacsxU', 'Content-Type': 'application/json'}, params=None)
+        self.mock_http.get.assert_called_once_with('{}/admin/template'.format(self.base_url), headers={'X-Idfy-SDK': 'Python {}'.format(version), 'Authorization': 'Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJmb28iOiJiYXIifQ.UIZchxQD36xuhacrJF9HQ5SIUxH5HBiv9noESAacsxU', 'Content-Type': 'application/json'}, params=None)
 
     
     def test_create_template_async(self):
@@ -250,7 +250,7 @@ class TestAdminAsync(BaseTest):
 
         self.assertIsNotNone(data)
         #self.AssertEqual()
-        self.mock_http.post.assert_called_once_with('http://localhost:5000/admin/template', auth=None, data='{"unit": "test"}', headers={'X-Idfy-SDK': 'Python {}'.format(version), 'Authorization': 'Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJmb28iOiJiYXIifQ.UIZchxQD36xuhacrJF9HQ5SIUxH5HBiv9noESAacsxU', 'Content-Type': 'application/json'}, params=None)
+        self.mock_http.post.assert_called_once_with('{}/admin/template'.format(self.base_url), auth=None, data='{"unit": "test"}', headers={'X-Idfy-SDK': 'Python {}'.format(version), 'Authorization': 'Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJmb28iOiJiYXIifQ.UIZchxQD36xuhacrJF9HQ5SIUxH5HBiv9noESAacsxU', 'Content-Type': 'application/json'}, params=None)
 
 
     def test_get_template_async(self):
@@ -260,7 +260,7 @@ class TestAdminAsync(BaseTest):
 
         self.assertIsNotNone(data)
         #self.AssertEqual()
-        self.mock_http.get.assert_called_once_with('http://localhost:5000/admin/template/1', headers={'X-Idfy-SDK': 'Python {}'.format(version), 'Authorization': 'Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJmb28iOiJiYXIifQ.UIZchxQD36xuhacrJF9HQ5SIUxH5HBiv9noESAacsxU', 'Content-Type': 'application/json'}, params=None)
+        self.mock_http.get.assert_called_once_with('{}/admin/template/1'.format(self.base_url), headers={'X-Idfy-SDK': 'Python {}'.format(version), 'Authorization': 'Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJmb28iOiJiYXIifQ.UIZchxQD36xuhacrJF9HQ5SIUxH5HBiv9noESAacsxU', 'Content-Type': 'application/json'}, params=None)
 
     
     def test_update_template_async(self):
@@ -270,7 +270,7 @@ class TestAdminAsync(BaseTest):
         
         self.assertIsNotNone(data)
         #self.AssertEqual()
-        self.mock_http.put.assert_called_once_with('http://localhost:5000/admin/template/1', data='{"unit": "test"}', headers={'X-Idfy-SDK': 'Python {}'.format(version), 'Authorization': 'Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJmb28iOiJiYXIifQ.UIZchxQD36xuhacrJF9HQ5SIUxH5HBiv9noESAacsxU', 'Content-Type': 'application/json'}, params=None)
+        self.mock_http.put.assert_called_once_with('{}/admin/template/1'.format(self.base_url), data='{"unit": "test"}', headers={'X-Idfy-SDK': 'Python {}'.format(version), 'Authorization': 'Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJmb28iOiJiYXIifQ.UIZchxQD36xuhacrJF9HQ5SIUxH5HBiv9noESAacsxU', 'Content-Type': 'application/json'}, params=None)
 
     
     def test_delete_template_async(self):
@@ -280,7 +280,7 @@ class TestAdminAsync(BaseTest):
 
         self.assertIsNone(data)
         #self.AssertEqual()
-        self.mock_http.delete.assert_called_once_with('http://localhost:5000/admin/template/1', headers={'X-Idfy-SDK': 'Python {}'.format(version), 'Authorization': 'Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJmb28iOiJiYXIifQ.UIZchxQD36xuhacrJF9HQ5SIUxH5HBiv9noESAacsxU', 'Content-Type': 'application/json'})
+        self.mock_http.delete.assert_called_once_with('{}/admin/template/1'.format(self.base_url), headers={'X-Idfy-SDK': 'Python {}'.format(version), 'Authorization': 'Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJmb28iOiJiYXIifQ.UIZchxQD36xuhacrJF9HQ5SIUxH5HBiv9noESAacsxU', 'Content-Type': 'application/json'})
 
 
 

--- a/test/test_services/test_identification.py
+++ b/test/test_services/test_identification.py
@@ -18,49 +18,49 @@ class TestIdentification(BaseTest):
 
         self.assertIsNotNone(data)
         #self.AssertEqual()
-        self.mock_http.get.assert_called_once_with('http://localhost:5000/identification/session', headers={'X-Idfy-SDK': 'Python {}'.format(version), 'Authorization': 'Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJmb28iOiJiYXIifQ.UIZchxQD36xuhacrJF9HQ5SIUxH5HBiv9noESAacsxU', 'Content-Type': 'application/json'}, params={'requestId': '1', 'metaData': False})
+        self.mock_http.get.assert_called_once_with('{}/identification/session'.format(self.base_url), headers={'X-Idfy-SDK': 'Python {}'.format(version), 'Authorization': 'Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJmb28iOiJiYXIifQ.UIZchxQD36xuhacrJF9HQ5SIUxH5HBiv9noESAacsxU', 'Content-Type': 'application/json'}, params={'requestId': '1', 'metaData': False})
 
     def test_create_session(self):
         data = self.identification_service.create_session(create_identification_request=self.params)
 
         self.assertIsNotNone(data)
         #self.AssertEqual()
-        self.mock_http.post.assert_called_once_with('http://localhost:5000/identification/session', auth=None, data='{"unit": "test"}', headers={'X-Idfy-SDK': 'Python {}'.format(version), 'Authorization': 'Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJmb28iOiJiYXIifQ.UIZchxQD36xuhacrJF9HQ5SIUxH5HBiv9noESAacsxU', 'Content-Type': 'application/json'}, params=None)
+        self.mock_http.post.assert_called_once_with('{}/identification/session'.format(self.base_url), auth=None, data='{"unit": "test"}', headers={'X-Idfy-SDK': 'Python {}'.format(version), 'Authorization': 'Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJmb28iOiJiYXIifQ.UIZchxQD36xuhacrJF9HQ5SIUxH5HBiv9noESAacsxU', 'Content-Type': 'application/json'}, params=None)
 
     def test_get_session_status(self):
         data = self.identification_service.get_session_status(request_id="1")
 
         self.assertIsNotNone(data)
         #self.AssertEqual()
-        self.mock_http.get.assert_called_once_with('http://localhost:5000/identification/session/status', headers={'X-Idfy-SDK': 'Python {}'.format(version), 'Authorization': 'Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJmb28iOiJiYXIifQ.UIZchxQD36xuhacrJF9HQ5SIUxH5HBiv9noESAacsxU', 'Content-Type': 'application/json'}, params={'requestId': '1'})
+        self.mock_http.get.assert_called_once_with('{}/identification/session/status'.format(self.base_url), headers={'X-Idfy-SDK': 'Python {}'.format(version), 'Authorization': 'Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJmb28iOiJiYXIifQ.UIZchxQD36xuhacrJF9HQ5SIUxH5HBiv9noESAacsxU', 'Content-Type': 'application/json'}, params={'requestId': '1'})
 
     def test_invalidate_session(self):
         data = self.identification_service.invalidate_session(request_id="1")
 
         self.assertIsNotNone(data)
         #self.AssertEqual()
-        self.mock_http.put.assert_called_once_with('http://localhost:5000/identification/session/invalidate', data='{"RequestId": "1"}', headers={'X-Idfy-SDK': 'Python {}'.format(version), 'Authorization': 'Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJmb28iOiJiYXIifQ.UIZchxQD36xuhacrJF9HQ5SIUxH5HBiv9noESAacsxU', 'Content-Type': 'application/json'}, params=None)
+        self.mock_http.put.assert_called_once_with('{}/identification/session/invalidate'.format(self.base_url), data='{"RequestId": "1"}', headers={'X-Idfy-SDK': 'Python {}'.format(version), 'Authorization': 'Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJmb28iOiJiYXIifQ.UIZchxQD36xuhacrJF9HQ5SIUxH5HBiv9noESAacsxU', 'Content-Type': 'application/json'}, params=None)
 
     def test_get_log_entry(self):
         data = self.identification_service.get_log_entry(request_id="1")
 
         self.assertIsNotNone(data)
         #self.AssertEqual()
-        self.mock_http.get.assert_called_once_with('http://localhost:5000/identification/log/requestId/1', headers={'X-Idfy-SDK': 'Python {}'.format(version), 'Authorization': 'Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJmb28iOiJiYXIifQ.UIZchxQD36xuhacrJF9HQ5SIUxH5HBiv9noESAacsxU', 'Content-Type': 'application/json'}, params=None)
+        self.mock_http.get.assert_called_once_with('{}/identification/log/requestId/1'.format(self.base_url), headers={'X-Idfy-SDK': 'Python {}'.format(version), 'Authorization': 'Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJmb28iOiJiYXIifQ.UIZchxQD36xuhacrJF9HQ5SIUxH5HBiv9noESAacsxU', 'Content-Type': 'application/json'}, params=None)
 
     def test_list_log_entries(self):
         data = self.identification_service.list_log_entries(year="1")
 
         self.assertIsNotNone(data)
         #self.AssertEqual()
-        self.mock_http.get.assert_called_once_with('http://localhost:5000/identification/log/filter/1', headers={'X-Idfy-SDK': 'Python {}'.format(version), 'Authorization': 'Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJmb28iOiJiYXIifQ.UIZchxQD36xuhacrJF9HQ5SIUxH5HBiv9noESAacsxU', 'Content-Type': 'application/json'}, params={'month': None, 'day': None, 'status': None, 'identityProviderType': None, 'externalId': None, 'name': None, 'skip': None, 'pageSize': None})
+        self.mock_http.get.assert_called_once_with('{}/identification/log/filter/1'.format(self.base_url), headers={'X-Idfy-SDK': 'Python {}'.format(version), 'Authorization': 'Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJmb28iOiJiYXIifQ.UIZchxQD36xuhacrJF9HQ5SIUxH5HBiv9noESAacsxU', 'Content-Type': 'application/json'}, params={'month': None, 'day': None, 'status': None, 'identityProviderType': None, 'externalId': None, 'name': None, 'skip': None, 'pageSize': None})
 
     def test_create_bankId_mobile_session(self):
         data = self.identification_service.create_bankId_mobile_session(request="1")
 
         self.assertIsNotNone(data)
         #self.AssertEqual()
-        self.mock_http.post.assert_called_once_with('http://localhost:5000/identification/no/bankid/mobile', auth=None, data='"1"', headers={'X-Idfy-SDK': 'Python {}'.format(version), 'Authorization': 'Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJmb28iOiJiYXIifQ.UIZchxQD36xuhacrJF9HQ5SIUxH5HBiv9noESAacsxU', 'Content-Type': 'application/json'}, params=None)
+        self.mock_http.post.assert_called_once_with('{}/identification/no/bankid/mobile'.format(self.base_url), auth=None, data='"1"', headers={'X-Idfy-SDK': 'Python {}'.format(version), 'Authorization': 'Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJmb28iOiJiYXIifQ.UIZchxQD36xuhacrJF9HQ5SIUxH5HBiv9noESAacsxU', 'Content-Type': 'application/json'}, params=None)
 
 class TestIdentificationAsync(BaseTest):
     @classmethod
@@ -82,7 +82,7 @@ class TestIdentificationAsync(BaseTest):
         data = self.loop.run_until_complete(func())
         
         self.assertIsNotNone(data)
-        self.mock_http.get.assert_called_once_with('http://localhost:5000/identification/session', headers={'X-Idfy-SDK': 'Python {}'.format(version), 'Authorization': 'Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJmb28iOiJiYXIifQ.UIZchxQD36xuhacrJF9HQ5SIUxH5HBiv9noESAacsxU', 'Content-Type': 'application/json'}, params={'requestId': '1', 'metaData': False})
+        self.mock_http.get.assert_called_once_with('{}/identification/session'.format(self.base_url), headers={'X-Idfy-SDK': 'Python {}'.format(version), 'Authorization': 'Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJmb28iOiJiYXIifQ.UIZchxQD36xuhacrJF9HQ5SIUxH5HBiv9noESAacsxU', 'Content-Type': 'application/json'}, params={'requestId': '1', 'metaData': False})
 
     def test_create_session_async(self):
         async def func():
@@ -90,7 +90,7 @@ class TestIdentificationAsync(BaseTest):
         data = self.loop.run_until_complete(func())
 
         self.assertIsNotNone(data)
-        self.mock_http.post.assert_called_once_with('http://localhost:5000/identification/session', auth=None, data='{"unit": "test"}', headers={'X-Idfy-SDK': 'Python {}'.format(version), 'Authorization': 'Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJmb28iOiJiYXIifQ.UIZchxQD36xuhacrJF9HQ5SIUxH5HBiv9noESAacsxU', 'Content-Type': 'application/json'}, params=None)
+        self.mock_http.post.assert_called_once_with('{}/identification/session'.format(self.base_url), auth=None, data='{"unit": "test"}', headers={'X-Idfy-SDK': 'Python {}'.format(version), 'Authorization': 'Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJmb28iOiJiYXIifQ.UIZchxQD36xuhacrJF9HQ5SIUxH5HBiv9noESAacsxU', 'Content-Type': 'application/json'}, params=None)
     
     def test_get_session_status_async(self):
         async def func():
@@ -98,7 +98,7 @@ class TestIdentificationAsync(BaseTest):
         data = self.loop.run_until_complete(func())
         
         self.assertIsNotNone(data)
-        self.mock_http.get.assert_called_once_with('http://localhost:5000/identification/session/status', headers={'X-Idfy-SDK': 'Python {}'.format(version), 'Authorization': 'Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJmb28iOiJiYXIifQ.UIZchxQD36xuhacrJF9HQ5SIUxH5HBiv9noESAacsxU', 'Content-Type': 'application/json'}, params={'requestId': '1'})
+        self.mock_http.get.assert_called_once_with('{}/identification/session/status'.format(self.base_url), headers={'X-Idfy-SDK': 'Python {}'.format(version), 'Authorization': 'Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJmb28iOiJiYXIifQ.UIZchxQD36xuhacrJF9HQ5SIUxH5HBiv9noESAacsxU', 'Content-Type': 'application/json'}, params={'requestId': '1'})
     
     def test_invalidate_session_async(self):
         async def func():
@@ -106,7 +106,7 @@ class TestIdentificationAsync(BaseTest):
         data = self.loop.run_until_complete(func())
         
         self.assertIsNotNone(data)
-        self.mock_http.put.assert_called_once_with('http://localhost:5000/identification/session/invalidate', data='{"RequestId": "1"}', headers={'X-Idfy-SDK': 'Python {}'.format(version), 'Authorization': 'Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJmb28iOiJiYXIifQ.UIZchxQD36xuhacrJF9HQ5SIUxH5HBiv9noESAacsxU', 'Content-Type': 'application/json'}, params=None)
+        self.mock_http.put.assert_called_once_with('{}/identification/session/invalidate'.format(self.base_url), data='{"RequestId": "1"}', headers={'X-Idfy-SDK': 'Python {}'.format(version), 'Authorization': 'Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJmb28iOiJiYXIifQ.UIZchxQD36xuhacrJF9HQ5SIUxH5HBiv9noESAacsxU', 'Content-Type': 'application/json'}, params=None)
     
     def test_get_log_entry_async(self):
         async def func():
@@ -114,7 +114,7 @@ class TestIdentificationAsync(BaseTest):
         data = self.loop.run_until_complete(func())
         
         self.assertIsNotNone(data)
-        self.mock_http.get.assert_called_once_with('http://localhost:5000/identification/log/requestId/1', headers={'X-Idfy-SDK': 'Python {}'.format(version), 'Authorization': 'Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJmb28iOiJiYXIifQ.UIZchxQD36xuhacrJF9HQ5SIUxH5HBiv9noESAacsxU', 'Content-Type': 'application/json'}, params=None)
+        self.mock_http.get.assert_called_once_with('{}/identification/log/requestId/1'.format(self.base_url), headers={'X-Idfy-SDK': 'Python {}'.format(version), 'Authorization': 'Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJmb28iOiJiYXIifQ.UIZchxQD36xuhacrJF9HQ5SIUxH5HBiv9noESAacsxU', 'Content-Type': 'application/json'}, params=None)
     
     def test_list_log_entries_async(self):
         async def func():
@@ -122,7 +122,7 @@ class TestIdentificationAsync(BaseTest):
         data = self.loop.run_until_complete(func())
         
         self.assertIsNotNone(data)
-        self.mock_http.get.assert_called_once_with('http://localhost:5000/identification/log/filter/1', headers={'X-Idfy-SDK': 'Python {}'.format(version), 'Authorization': 'Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJmb28iOiJiYXIifQ.UIZchxQD36xuhacrJF9HQ5SIUxH5HBiv9noESAacsxU', 'Content-Type': 'application/json'}, params={'month': None, 'day': None, 'status': None, 'identityProviderType': None, 'externalId': None, 'name': None, 'skip': None, 'pageSize': None})
+        self.mock_http.get.assert_called_once_with('{}/identification/log/filter/1'.format(self.base_url), headers={'X-Idfy-SDK': 'Python {}'.format(version), 'Authorization': 'Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJmb28iOiJiYXIifQ.UIZchxQD36xuhacrJF9HQ5SIUxH5HBiv9noESAacsxU', 'Content-Type': 'application/json'}, params={'month': None, 'day': None, 'status': None, 'identityProviderType': None, 'externalId': None, 'name': None, 'skip': None, 'pageSize': None})
     
     def test_create_bankId_mobile_session_async(self):
         async def func():
@@ -130,4 +130,4 @@ class TestIdentificationAsync(BaseTest):
         data = self.loop.run_until_complete(func())
         
         self.assertIsNotNone(data)
-        self.mock_http.post.assert_called_once_with('http://localhost:5000/identification/no/bankid/mobile', auth=None, data='"1"', headers={'X-Idfy-SDK': 'Python {}'.format(version), 'Authorization': 'Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJmb28iOiJiYXIifQ.UIZchxQD36xuhacrJF9HQ5SIUxH5HBiv9noESAacsxU', 'Content-Type': 'application/json'}, params=None)
+        self.mock_http.post.assert_called_once_with('{}/identification/no/bankid/mobile'.format(self.base_url), auth=None, data='"1"', headers={'X-Idfy-SDK': 'Python {}'.format(version), 'Authorization': 'Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJmb28iOiJiYXIifQ.UIZchxQD36xuhacrJF9HQ5SIUxH5HBiv9noESAacsxU', 'Content-Type': 'application/json'}, params=None)

--- a/test/test_services/test_jwt.py
+++ b/test/test_services/test_jwt.py
@@ -18,7 +18,7 @@ class TestJwt(BaseTest):
 
         self.assertIsNotNone(data)
         #self.AssertEqual()
-        self.mock_http.post.assert_called_once_with('http://localhost:5000/jwt/validate', auth=None, data='{"unit": "test"}', headers={'X-Idfy-SDK': 'Python {}'.format(version), 'Authorization': 'Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJmb28iOiJiYXIifQ.UIZchxQD36xuhacrJF9HQ5SIUxH5HBiv9noESAacsxU', 'Content-Type': 'application/json'}, params=None)
+        self.mock_http.post.assert_called_once_with('{}/jwt/validate'.format(self.base_url), auth=None, data='{"unit": "test"}', headers={'X-Idfy-SDK': 'Python {}'.format(version), 'Authorization': 'Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJmb28iOiJiYXIifQ.UIZchxQD36xuhacrJF9HQ5SIUxH5HBiv9noESAacsxU', 'Content-Type': 'application/json'}, params=None)
 
 class TestJwtAsync(BaseTest):
     @classmethod
@@ -41,5 +41,5 @@ class TestJwtAsync(BaseTest):
         
         self.assertIsNotNone(data)
         #self.AssertEqual()
-        self.mock_http.post.assert_called_once_with('http://localhost:5000/jwt/validate', auth=None, data='{"unit": "test"}', headers={'X-Idfy-SDK': 'Python {}'.format(version), 'Authorization': 'Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJmb28iOiJiYXIifQ.UIZchxQD36xuhacrJF9HQ5SIUxH5HBiv9noESAacsxU', 'Content-Type': 'application/json'}, params=None)
+        self.mock_http.post.assert_called_once_with('{}/jwt/validate'.format(self.base_url), auth=None, data='{"unit": "test"}', headers={'X-Idfy-SDK': 'Python {}'.format(version), 'Authorization': 'Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJmb28iOiJiYXIifQ.UIZchxQD36xuhacrJF9HQ5SIUxH5HBiv9noESAacsxU', 'Content-Type': 'application/json'}, params=None)
 

--- a/test/test_services/test_merchant_sign.py
+++ b/test/test_services/test_merchant_sign.py
@@ -18,28 +18,28 @@ class TestMerchantSign(BaseTest):
 
         self.assertIsNotNone(data)
         #self.AssertEqual()
-        self.mock_http.post.assert_called_once_with('http://localhost:5000/merchant/signature', auth=None, data='{"unit": "test"}', headers={'X-Idfy-SDK': 'Python {}'.format(version), 'Authorization': 'Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJmb28iOiJiYXIifQ.UIZchxQD36xuhacrJF9HQ5SIUxH5HBiv9noESAacsxU', 'Content-Type': 'application/json'}, params=None)
+        self.mock_http.post.assert_called_once_with('{}/merchant/signature'.format(self.base_url), auth=None, data='{"unit": "test"}', headers={'X-Idfy-SDK': 'Python {}'.format(version), 'Authorization': 'Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJmb28iOiJiYXIifQ.UIZchxQD36xuhacrJF9HQ5SIUxH5HBiv9noESAacsxU', 'Content-Type': 'application/json'}, params=None)
 
     def test_get_transaction(self):
         data = self.merchant_sign_service.get_transaction(transaction_id="1")
 
         self.assertIsNotNone(data)
         #self.AssertEqual()
-        self.mock_http.get.assert_called_once_with('http://localhost:5000/merchant/signature/1', headers={'X-Idfy-SDK': 'Python {}'.format(version), 'Authorization': 'Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJmb28iOiJiYXIifQ.UIZchxQD36xuhacrJF9HQ5SIUxH5HBiv9noESAacsxU', 'Content-Type': 'application/json'}, params=None)
+        self.mock_http.get.assert_called_once_with('{}/merchant/signature/1'.format(self.base_url), headers={'X-Idfy-SDK': 'Python {}'.format(version), 'Authorization': 'Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJmb28iOiJiYXIifQ.UIZchxQD36xuhacrJF9HQ5SIUxH5HBiv9noESAacsxU', 'Content-Type': 'application/json'}, params=None)
 
     def test_list_transactions(self):
         data = self.merchant_sign_service.list_transactions()
 
         self.assertIsNotNone(data)
         #self.AssertEqual()
-        self.mock_http.get.assert_called_once_with('http://localhost:5000/merchant/signature/list', headers={'X-Idfy-SDK': 'Python {}'.format(version), 'Authorization': 'Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJmb28iOiJiYXIifQ.UIZchxQD36xuhacrJF9HQ5SIUxH5HBiv9noESAacsxU', 'Content-Type': 'application/json'}, params={'oauthClientId': None, 'fromDate': None, 'to_date': None})
+        self.mock_http.get.assert_called_once_with('{}/merchant/signature/list'.format(self.base_url), headers={'X-Idfy-SDK': 'Python {}'.format(version), 'Authorization': 'Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJmb28iOiJiYXIifQ.UIZchxQD36xuhacrJF9HQ5SIUxH5HBiv9noESAacsxU', 'Content-Type': 'application/json'}, params={'oauthClientId': None, 'fromDate': None, 'to_date': None})
     #@unittest.skip("Mock server error")
     #def test_get_pades(self):
     #    data = self.merchant_sign_service.get_pades(signed_document_id="1")
 #
     #    self.assertIsNotNone(data)
     #    #self.AssertEqual()
-    #    self.mock_http.get.assert_called_once_with('http://localhost:5000/merchant/pades/1', headers={'X-Idfy-SDK': 'Python {}'.format(version), 'Authorization': 'Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJmb28iOiJiYXIifQ.UIZchxQD36xuhacrJF9HQ5SIUxH5HBiv9noESAacsxU', 'Content-Type': 'application/json'}, params=None)
+    #    self.mock_http.get.assert_called_once_with('{}/merchant/pades/1'.format(self.base_url), headers={'X-Idfy-SDK': 'Python {}'.format(version), 'Authorization': 'Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJmb28iOiJiYXIifQ.UIZchxQD36xuhacrJF9HQ5SIUxH5HBiv9noESAacsxU', 'Content-Type': 'application/json'}, params=None)
 
 
 class TestMerchantSignAsync(BaseTest):
@@ -63,7 +63,7 @@ class TestMerchantSignAsync(BaseTest):
 
         
         self.assertIsNotNone(data)
-        self.mock_http.post.assert_called_once_with('http://localhost:5000/merchant/signature', auth=None, data='{"unit": "test"}', headers={'X-Idfy-SDK': 'Python {}'.format(version), 'Authorization': 'Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJmb28iOiJiYXIifQ.UIZchxQD36xuhacrJF9HQ5SIUxH5HBiv9noESAacsxU', 'Content-Type': 'application/json'}, params=None)
+        self.mock_http.post.assert_called_once_with('{}/merchant/signature'.format(self.base_url), auth=None, data='{"unit": "test"}', headers={'X-Idfy-SDK': 'Python {}'.format(version), 'Authorization': 'Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJmb28iOiJiYXIifQ.UIZchxQD36xuhacrJF9HQ5SIUxH5HBiv9noESAacsxU', 'Content-Type': 'application/json'}, params=None)
     
     def test_get_transaction(self):
         async def func():
@@ -72,7 +72,7 @@ class TestMerchantSignAsync(BaseTest):
 
         
         self.assertIsNotNone(data)
-        self.mock_http.get.assert_called_once_with('http://localhost:5000/merchant/signature/1', headers={'X-Idfy-SDK': 'Python {}'.format(version), 'Authorization': 'Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJmb28iOiJiYXIifQ.UIZchxQD36xuhacrJF9HQ5SIUxH5HBiv9noESAacsxU', 'Content-Type': 'application/json'}, params=None)
+        self.mock_http.get.assert_called_once_with('{}/merchant/signature/1'.format(self.base_url), headers={'X-Idfy-SDK': 'Python {}'.format(version), 'Authorization': 'Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJmb28iOiJiYXIifQ.UIZchxQD36xuhacrJF9HQ5SIUxH5HBiv9noESAacsxU', 'Content-Type': 'application/json'}, params=None)
     
     def test_list_transactions(self):
         async def func():
@@ -80,7 +80,7 @@ class TestMerchantSignAsync(BaseTest):
         data = self.loop.run_until_complete(func())
 
         self.assertIsNotNone(data)
-        self.mock_http.get.assert_called_once_with('http://localhost:5000/merchant/signature/list', headers={'X-Idfy-SDK': 'Python {}'.format(version), 'Authorization': 'Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJmb28iOiJiYXIifQ.UIZchxQD36xuhacrJF9HQ5SIUxH5HBiv9noESAacsxU', 'Content-Type': 'application/json'}, params={'oauthClientId': None, 'fromDate': None, 'to_date': None})
+        self.mock_http.get.assert_called_once_with('{}/merchant/signature/list'.format(self.base_url), headers={'X-Idfy-SDK': 'Python {}'.format(version), 'Authorization': 'Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJmb28iOiJiYXIifQ.UIZchxQD36xuhacrJF9HQ5SIUxH5HBiv9noESAacsxU', 'Content-Type': 'application/json'}, params={'oauthClientId': None, 'fromDate': None, 'to_date': None})
     #@unittest.skip("Mock server error")
     #def test_get_pades(self):
     #    async def func():
@@ -89,4 +89,4 @@ class TestMerchantSignAsync(BaseTest):
 #
     #    
     #    self.assertIsNotNone(data)
-    #    self.mock_http.get.assert_called_once_with('http://localhost:5000/merchant/pades/1', headers={'X-Idfy-SDK': 'Python {}'.format(version), 'Authorization': 'Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJmb28iOiJiYXIifQ.UIZchxQD36xuhacrJF9HQ5SIUxH5HBiv9noESAacsxU', 'Content-Type': 'application/json'}, params=None)
+    #    self.mock_http.get.assert_called_once_with('{}/merchant/pades/1'.format(self.base_url), headers={'X-Idfy-SDK': 'Python {}'.format(version), 'Authorization': 'Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJmb28iOiJiYXIifQ.UIZchxQD36xuhacrJF9HQ5SIUxH5HBiv9noESAacsxU', 'Content-Type': 'application/json'}, params=None)

--- a/test/test_services/test_notification.py
+++ b/test/test_services/test_notification.py
@@ -18,7 +18,7 @@ class TestNotification(BaseTest):
 
         self.assertIsNotNone(data)
         #self.AssertEqual()
-        self.mock_http.get.assert_called_once_with('http://localhost:5000/notification/events', headers={'X-Idfy-SDK': 'Python {}'.format(version), 'Authorization': 'Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJmb28iOiJiYXIifQ.UIZchxQD36xuhacrJF9HQ5SIUxH5HBiv9noESAacsxU', 'Content-Type': 'application/json'}, params={'eventType': None, 'tags': None})
+        self.mock_http.get.assert_called_once_with('{}/notification/events'.format(self.base_url), headers={'X-Idfy-SDK': 'Python {}'.format(version), 'Authorization': 'Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJmb28iOiJiYXIifQ.UIZchxQD36xuhacrJF9HQ5SIUxH5HBiv9noESAacsxU', 'Content-Type': 'application/json'}, params={'eventType': None, 'tags': None})
 
 
     def test_handle_event(self):
@@ -26,7 +26,7 @@ class TestNotification(BaseTest):
 
         self.assertIsNotNone(data)
         #self.AssertEqual()
-        self.mock_http.post.assert_called_once_with('http://localhost:5000/notification/events/1/handle', auth=None, data='null', headers={'X-Idfy-SDK': 'Python {}'.format(version), 'Authorization': 'Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJmb28iOiJiYXIifQ.UIZchxQD36xuhacrJF9HQ5SIUxH5HBiv9noESAacsxU', 'Content-Type': 'application/json'}, params=None)
+        self.mock_http.post.assert_called_once_with('{}/notification/events/1/handle'.format(self.base_url), auth=None, data='null', headers={'X-Idfy-SDK': 'Python {}'.format(version), 'Authorization': 'Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJmb28iOiJiYXIifQ.UIZchxQD36xuhacrJF9HQ5SIUxH5HBiv9noESAacsxU', 'Content-Type': 'application/json'}, params=None)
 
 
     def test_handle_multiple_events(self):
@@ -34,7 +34,7 @@ class TestNotification(BaseTest):
 
         self.assertIsNotNone(data)
         #self.AssertEqual()
-        self.mock_http.post.assert_called_once_with('http://localhost:5000/notification/events/handle', auth=None, data='"1"', headers={'X-Idfy-SDK': 'Python {}'.format(version), 'Authorization': 'Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJmb28iOiJiYXIifQ.UIZchxQD36xuhacrJF9HQ5SIUxH5HBiv9noESAacsxU', 'Content-Type': 'application/json'}, params=None)
+        self.mock_http.post.assert_called_once_with('{}/notification/events/handle'.format(self.base_url), auth=None, data='"1"', headers={'X-Idfy-SDK': 'Python {}'.format(version), 'Authorization': 'Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJmb28iOiJiYXIifQ.UIZchxQD36xuhacrJF9HQ5SIUxH5HBiv9noESAacsxU', 'Content-Type': 'application/json'}, params=None)
 
 
     def test_peek_events(self):
@@ -42,7 +42,7 @@ class TestNotification(BaseTest):
 
         self.assertIsNotNone(data)
         #self.AssertEqual()
-        self.mock_http.get.assert_called_once_with('http://localhost:5000/notification/events/peek', headers={'X-Idfy-SDK': 'Python {}'.format(version), 'Authorization': 'Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJmb28iOiJiYXIifQ.UIZchxQD36xuhacrJF9HQ5SIUxH5HBiv9noESAacsxU', 'Content-Type': 'application/json'}, params={'eventType': None, 'tags': None})
+        self.mock_http.get.assert_called_once_with('{}/notification/events/peek'.format(self.base_url), headers={'X-Idfy-SDK': 'Python {}'.format(version), 'Authorization': 'Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJmb28iOiJiYXIifQ.UIZchxQD36xuhacrJF9HQ5SIUxH5HBiv9noESAacsxU', 'Content-Type': 'application/json'}, params={'eventType': None, 'tags': None})
 
 
     def test_clear_events(self):
@@ -50,7 +50,7 @@ class TestNotification(BaseTest):
 
         self.assertIsNotNone(data)
         #self.AssertEqual()
-        self.mock_http.post.assert_called_once_with('http://localhost:5000/notification/events/clear', auth=None, data='null', headers={'X-Idfy-SDK': 'Python {}'.format(version), 'Authorization': 'Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJmb28iOiJiYXIifQ.UIZchxQD36xuhacrJF9HQ5SIUxH5HBiv9noESAacsxU', 'Content-Type': 'application/json'}, params=None)
+        self.mock_http.post.assert_called_once_with('{}/notification/events/clear'.format(self.base_url), auth=None, data='null', headers={'X-Idfy-SDK': 'Python {}'.format(version), 'Authorization': 'Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJmb28iOiJiYXIifQ.UIZchxQD36xuhacrJF9HQ5SIUxH5HBiv9noESAacsxU', 'Content-Type': 'application/json'}, params=None)
 
 
     def test_list_event_types(self):
@@ -58,7 +58,7 @@ class TestNotification(BaseTest):
 
         self.assertIsNotNone(data)
         #self.AssertEqual()
-        self.mock_http.get.assert_called_once_with('http://localhost:5000/notification/events/types', headers={'X-Idfy-SDK': 'Python {}'.format(version), 'Authorization': 'Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJmb28iOiJiYXIifQ.UIZchxQD36xuhacrJF9HQ5SIUxH5HBiv9noESAacsxU', 'Content-Type': 'application/json'}, params=None)
+        self.mock_http.get.assert_called_once_with('{}/notification/events/types'.format(self.base_url), headers={'X-Idfy-SDK': 'Python {}'.format(version), 'Authorization': 'Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJmb28iOiJiYXIifQ.UIZchxQD36xuhacrJF9HQ5SIUxH5HBiv9noESAacsxU', 'Content-Type': 'application/json'}, params=None)
 
 
     def test_mock_event(self):
@@ -66,7 +66,7 @@ class TestNotification(BaseTest):
 
         self.assertIsNotNone(data)
         #self.AssertEqual()
-        self.mock_http.post.assert_called_once_with('http://localhost:5000/notification/events/mock', auth=None, data='{"unit": "test"}', headers={'X-Idfy-SDK': 'Python {}'.format(version), 'Authorization': 'Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJmb28iOiJiYXIifQ.UIZchxQD36xuhacrJF9HQ5SIUxH5HBiv9noESAacsxU', 'Content-Type': 'application/json'}, params=None)
+        self.mock_http.post.assert_called_once_with('{}/notification/events/mock'.format(self.base_url), auth=None, data='{"unit": "test"}', headers={'X-Idfy-SDK': 'Python {}'.format(version), 'Authorization': 'Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJmb28iOiJiYXIifQ.UIZchxQD36xuhacrJF9HQ5SIUxH5HBiv9noESAacsxU', 'Content-Type': 'application/json'}, params=None)
 
 
     def test_get_webhook(self):
@@ -74,7 +74,7 @@ class TestNotification(BaseTest):
 
         self.assertIsNotNone(data)
         #self.AssertEqual()
-        self.mock_http.get.assert_called_once_with('http://localhost:5000/notification/webhooks/1', headers={'X-Idfy-SDK': 'Python {}'.format(version), 'Authorization': 'Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJmb28iOiJiYXIifQ.UIZchxQD36xuhacrJF9HQ5SIUxH5HBiv9noESAacsxU', 'Content-Type': 'application/json'}, params=None)
+        self.mock_http.get.assert_called_once_with('{}/notification/webhooks/1'.format(self.base_url), headers={'X-Idfy-SDK': 'Python {}'.format(version), 'Authorization': 'Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJmb28iOiJiYXIifQ.UIZchxQD36xuhacrJF9HQ5SIUxH5HBiv9noESAacsxU', 'Content-Type': 'application/json'}, params=None)
 
 
     def test_delete_webhook(self):
@@ -82,7 +82,7 @@ class TestNotification(BaseTest):
 
         self.assertIsNone(data)
         #self.AssertEqual()
-        self.mock_http.delete.assert_called_once_with('http://localhost:5000/notification/webhooks/1', headers={'X-Idfy-SDK': 'Python {}'.format(version), 'Authorization': 'Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJmb28iOiJiYXIifQ.UIZchxQD36xuhacrJF9HQ5SIUxH5HBiv9noESAacsxU', 'Content-Type': 'application/json'})
+        self.mock_http.delete.assert_called_once_with('{}/notification/webhooks/1'.format(self.base_url), headers={'X-Idfy-SDK': 'Python {}'.format(version), 'Authorization': 'Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJmb28iOiJiYXIifQ.UIZchxQD36xuhacrJF9HQ5SIUxH5HBiv9noESAacsxU', 'Content-Type': 'application/json'})
 
 
     def test_update_webhook(self):
@@ -90,7 +90,7 @@ class TestNotification(BaseTest):
 
         self.assertIsNotNone(data)
         #self.AssertEqual()
-        self.mock_http.patch.assert_called_once_with('http://localhost:5000/notification/webhooks/1', data='{"unit": "test"}', headers={'X-Idfy-SDK': 'Python {}'.format(version), 'Authorization': 'Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJmb28iOiJiYXIifQ.UIZchxQD36xuhacrJF9HQ5SIUxH5HBiv9noESAacsxU', 'Content-Type': 'application/json'})
+        self.mock_http.patch.assert_called_once_with('{}/notification/webhooks/1'.format(self.base_url), data='{"unit": "test"}', headers={'X-Idfy-SDK': 'Python {}'.format(version), 'Authorization': 'Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJmb28iOiJiYXIifQ.UIZchxQD36xuhacrJF9HQ5SIUxH5HBiv9noESAacsxU', 'Content-Type': 'application/json'})
 
 
     def test_list_webhooks(self):
@@ -98,7 +98,7 @@ class TestNotification(BaseTest):
 
         self.assertIsNotNone(data)
         #self.AssertEqual()
-        self.mock_http.get.assert_called_once_with('http://localhost:5000/notification/webhooks', headers={'X-Idfy-SDK': 'Python {}'.format(version), 'Authorization': 'Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJmb28iOiJiYXIifQ.UIZchxQD36xuhacrJF9HQ5SIUxH5HBiv9noESAacsxU', 'Content-Type': 'application/json'}, params=None)
+        self.mock_http.get.assert_called_once_with('{}/notification/webhooks'.format(self.base_url), headers={'X-Idfy-SDK': 'Python {}'.format(version), 'Authorization': 'Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJmb28iOiJiYXIifQ.UIZchxQD36xuhacrJF9HQ5SIUxH5HBiv9noESAacsxU', 'Content-Type': 'application/json'}, params=None)
 
 
     def test_create_webhook(self):
@@ -106,7 +106,7 @@ class TestNotification(BaseTest):
 
         self.assertIsNotNone(data)
         #self.AssertEqual()
-        self.mock_http.post.assert_called_once_with('http://localhost:5000/notification/webhooks', auth=None, data='{"unit": "test"}', headers={'X-Idfy-SDK': 'Python {}'.format(version), 'Authorization': 'Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJmb28iOiJiYXIifQ.UIZchxQD36xuhacrJF9HQ5SIUxH5HBiv9noESAacsxU', 'Content-Type': 'application/json'}, params=None)
+        self.mock_http.post.assert_called_once_with('{}/notification/webhooks'.format(self.base_url), auth=None, data='{"unit": "test"}', headers={'X-Idfy-SDK': 'Python {}'.format(version), 'Authorization': 'Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJmb28iOiJiYXIifQ.UIZchxQD36xuhacrJF9HQ5SIUxH5HBiv9noESAacsxU', 'Content-Type': 'application/json'}, params=None)
 
 
     def test_ping_webhook(self):
@@ -114,7 +114,7 @@ class TestNotification(BaseTest):
 
         self.assertIsNotNone(data)
         #self.AssertEqual()
-        self.mock_http.post.assert_called_once_with('http://localhost:5000/notification/webhooks/1/ping', auth=None, data='null', headers={'X-Idfy-SDK': 'Python {}'.format(version), 'Authorization': 'Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJmb28iOiJiYXIifQ.UIZchxQD36xuhacrJF9HQ5SIUxH5HBiv9noESAacsxU', 'Content-Type': 'application/json'}, params=None)
+        self.mock_http.post.assert_called_once_with('{}/notification/webhooks/1/ping'.format(self.base_url), auth=None, data='null', headers={'X-Idfy-SDK': 'Python {}'.format(version), 'Authorization': 'Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJmb28iOiJiYXIifQ.UIZchxQD36xuhacrJF9HQ5SIUxH5HBiv9noESAacsxU', 'Content-Type': 'application/json'}, params=None)
 
 
     def test_list_webhook_deliveries(self):
@@ -122,7 +122,7 @@ class TestNotification(BaseTest):
 
         self.assertIsNotNone(data)
         #self.AssertEqual()
-        self.mock_http.get.assert_called_once_with('http://localhost:5000/notification/webhooks/1/deliveries', headers={'X-Idfy-SDK': 'Python {}'.format(version), 'Authorization': 'Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJmb28iOiJiYXIifQ.UIZchxQD36xuhacrJF9HQ5SIUxH5HBiv9noESAacsxU', 'Content-Type': 'application/json'}, params=None)
+        self.mock_http.get.assert_called_once_with('{}/notification/webhooks/1/deliveries'.format(self.base_url), headers={'X-Idfy-SDK': 'Python {}'.format(version), 'Authorization': 'Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJmb28iOiJiYXIifQ.UIZchxQD36xuhacrJF9HQ5SIUxH5HBiv9noESAacsxU', 'Content-Type': 'application/json'}, params=None)
 
 class TestNotificationAsync(BaseTest):
     @classmethod
@@ -144,7 +144,7 @@ class TestNotificationAsync(BaseTest):
         data = self.loop.run_until_complete(func())
         
         self.assertIsNotNone(data)
-        self.mock_http.get.assert_called_once_with('http://localhost:5000/notification/events', headers={'X-Idfy-SDK': 'Python {}'.format(version), 'Authorization': 'Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJmb28iOiJiYXIifQ.UIZchxQD36xuhacrJF9HQ5SIUxH5HBiv9noESAacsxU', 'Content-Type': 'application/json'}, params={'eventType': None, 'tags': None})
+        self.mock_http.get.assert_called_once_with('{}/notification/events'.format(self.base_url), headers={'X-Idfy-SDK': 'Python {}'.format(version), 'Authorization': 'Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJmb28iOiJiYXIifQ.UIZchxQD36xuhacrJF9HQ5SIUxH5HBiv9noESAacsxU', 'Content-Type': 'application/json'}, params={'eventType': None, 'tags': None})
     
     def test_handle_event_async(self):
         async def func():
@@ -152,7 +152,7 @@ class TestNotificationAsync(BaseTest):
         data = self.loop.run_until_complete(func())
         
         self.assertIsNotNone(data)
-        self.mock_http.post.assert_called_once_with('http://localhost:5000/notification/events/1/handle', auth=None, data='null', headers={'X-Idfy-SDK': 'Python {}'.format(version), 'Authorization': 'Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJmb28iOiJiYXIifQ.UIZchxQD36xuhacrJF9HQ5SIUxH5HBiv9noESAacsxU', 'Content-Type': 'application/json'}, params=None)
+        self.mock_http.post.assert_called_once_with('{}/notification/events/1/handle'.format(self.base_url), auth=None, data='null', headers={'X-Idfy-SDK': 'Python {}'.format(version), 'Authorization': 'Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJmb28iOiJiYXIifQ.UIZchxQD36xuhacrJF9HQ5SIUxH5HBiv9noESAacsxU', 'Content-Type': 'application/json'}, params=None)
     
     def test_handle_multiple_events_async(self):
         async def func():
@@ -160,7 +160,7 @@ class TestNotificationAsync(BaseTest):
         data = self.loop.run_until_complete(func())
         
         self.assertIsNotNone(data)
-        self.mock_http.post.assert_called_once_with('http://localhost:5000/notification/events/handle', auth=None, data='"1"', headers={'X-Idfy-SDK': 'Python {}'.format(version), 'Authorization': 'Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJmb28iOiJiYXIifQ.UIZchxQD36xuhacrJF9HQ5SIUxH5HBiv9noESAacsxU', 'Content-Type': 'application/json'}, params=None)
+        self.mock_http.post.assert_called_once_with('{}/notification/events/handle'.format(self.base_url), auth=None, data='"1"', headers={'X-Idfy-SDK': 'Python {}'.format(version), 'Authorization': 'Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJmb28iOiJiYXIifQ.UIZchxQD36xuhacrJF9HQ5SIUxH5HBiv9noESAacsxU', 'Content-Type': 'application/json'}, params=None)
     
     def test_peek_events_async(self):
         async def func():
@@ -168,7 +168,7 @@ class TestNotificationAsync(BaseTest):
         data = self.loop.run_until_complete(func())
         
         self.assertIsNotNone(data)
-        self.mock_http.get.assert_called_once_with('http://localhost:5000/notification/events/peek', headers={'X-Idfy-SDK': 'Python {}'.format(version), 'Authorization': 'Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJmb28iOiJiYXIifQ.UIZchxQD36xuhacrJF9HQ5SIUxH5HBiv9noESAacsxU', 'Content-Type': 'application/json'}, params={'eventType': None, 'tags': None})
+        self.mock_http.get.assert_called_once_with('{}/notification/events/peek'.format(self.base_url), headers={'X-Idfy-SDK': 'Python {}'.format(version), 'Authorization': 'Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJmb28iOiJiYXIifQ.UIZchxQD36xuhacrJF9HQ5SIUxH5HBiv9noESAacsxU', 'Content-Type': 'application/json'}, params={'eventType': None, 'tags': None})
     
     def test_clear_events_async(self):
         async def func():
@@ -176,7 +176,7 @@ class TestNotificationAsync(BaseTest):
         data = self.loop.run_until_complete(func())
         
         self.assertIsNotNone(data)
-        self.mock_http.post.assert_called_once_with('http://localhost:5000/notification/events/clear', auth=None, data='null', headers={'X-Idfy-SDK': 'Python {}'.format(version), 'Authorization': 'Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJmb28iOiJiYXIifQ.UIZchxQD36xuhacrJF9HQ5SIUxH5HBiv9noESAacsxU', 'Content-Type': 'application/json'}, params=None)
+        self.mock_http.post.assert_called_once_with('{}/notification/events/clear'.format(self.base_url), auth=None, data='null', headers={'X-Idfy-SDK': 'Python {}'.format(version), 'Authorization': 'Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJmb28iOiJiYXIifQ.UIZchxQD36xuhacrJF9HQ5SIUxH5HBiv9noESAacsxU', 'Content-Type': 'application/json'}, params=None)
 
     def test_list_event_types_async(self):
         async def func():
@@ -184,7 +184,7 @@ class TestNotificationAsync(BaseTest):
         data = self.loop.run_until_complete(func())
         
         self.assertIsNotNone(data)
-        self.mock_http.get.assert_called_once_with('http://localhost:5000/notification/events/types', headers={'X-Idfy-SDK': 'Python {}'.format(version), 'Authorization': 'Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJmb28iOiJiYXIifQ.UIZchxQD36xuhacrJF9HQ5SIUxH5HBiv9noESAacsxU', 'Content-Type': 'application/json'}, params=None)
+        self.mock_http.get.assert_called_once_with('{}/notification/events/types'.format(self.base_url), headers={'X-Idfy-SDK': 'Python {}'.format(version), 'Authorization': 'Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJmb28iOiJiYXIifQ.UIZchxQD36xuhacrJF9HQ5SIUxH5HBiv9noESAacsxU', 'Content-Type': 'application/json'}, params=None)
     
     def test_mock_event_async(self):
         async def func():
@@ -192,7 +192,7 @@ class TestNotificationAsync(BaseTest):
         data = self.loop.run_until_complete(func())
         
         self.assertIsNotNone(data)
-        self.mock_http.post.assert_called_once_with('http://localhost:5000/notification/events/mock', auth=None, data='{"unit": "test"}', headers={'X-Idfy-SDK': 'Python {}'.format(version), 'Authorization': 'Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJmb28iOiJiYXIifQ.UIZchxQD36xuhacrJF9HQ5SIUxH5HBiv9noESAacsxU', 'Content-Type': 'application/json'}, params=None)
+        self.mock_http.post.assert_called_once_with('{}/notification/events/mock'.format(self.base_url), auth=None, data='{"unit": "test"}', headers={'X-Idfy-SDK': 'Python {}'.format(version), 'Authorization': 'Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJmb28iOiJiYXIifQ.UIZchxQD36xuhacrJF9HQ5SIUxH5HBiv9noESAacsxU', 'Content-Type': 'application/json'}, params=None)
     
     def test_get_webhook_async(self):
         async def func():
@@ -200,7 +200,7 @@ class TestNotificationAsync(BaseTest):
         data = self.loop.run_until_complete(func())
         
         self.assertIsNotNone(data)
-        self.mock_http.get.assert_called_once_with('http://localhost:5000/notification/webhooks/1', headers={'X-Idfy-SDK': 'Python {}'.format(version), 'Authorization': 'Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJmb28iOiJiYXIifQ.UIZchxQD36xuhacrJF9HQ5SIUxH5HBiv9noESAacsxU', 'Content-Type': 'application/json'}, params=None)
+        self.mock_http.get.assert_called_once_with('{}/notification/webhooks/1'.format(self.base_url), headers={'X-Idfy-SDK': 'Python {}'.format(version), 'Authorization': 'Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJmb28iOiJiYXIifQ.UIZchxQD36xuhacrJF9HQ5SIUxH5HBiv9noESAacsxU', 'Content-Type': 'application/json'}, params=None)
     
     def test_delete_webhook_async(self):
         async def func():
@@ -208,7 +208,7 @@ class TestNotificationAsync(BaseTest):
         data = self.loop.run_until_complete(func())
         
         self.assertIsNone(data)
-        self.mock_http.delete.assert_called_once_with('http://localhost:5000/notification/webhooks/1', headers={'X-Idfy-SDK': 'Python {}'.format(version), 'Authorization': 'Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJmb28iOiJiYXIifQ.UIZchxQD36xuhacrJF9HQ5SIUxH5HBiv9noESAacsxU', 'Content-Type': 'application/json'})
+        self.mock_http.delete.assert_called_once_with('{}/notification/webhooks/1'.format(self.base_url), headers={'X-Idfy-SDK': 'Python {}'.format(version), 'Authorization': 'Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJmb28iOiJiYXIifQ.UIZchxQD36xuhacrJF9HQ5SIUxH5HBiv9noESAacsxU', 'Content-Type': 'application/json'})
     
     def test_update_webhook_async(self):
         async def func():
@@ -216,7 +216,7 @@ class TestNotificationAsync(BaseTest):
         data = self.loop.run_until_complete(func())
         
         self.assertIsNotNone(data)
-        self.mock_http.patch.assert_called_once_with('http://localhost:5000/notification/webhooks/1', data='{"unit": "test"}', headers={'X-Idfy-SDK': 'Python {}'.format(version), 'Authorization': 'Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJmb28iOiJiYXIifQ.UIZchxQD36xuhacrJF9HQ5SIUxH5HBiv9noESAacsxU', 'Content-Type': 'application/json'})
+        self.mock_http.patch.assert_called_once_with('{}/notification/webhooks/1'.format(self.base_url), data='{"unit": "test"}', headers={'X-Idfy-SDK': 'Python {}'.format(version), 'Authorization': 'Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJmb28iOiJiYXIifQ.UIZchxQD36xuhacrJF9HQ5SIUxH5HBiv9noESAacsxU', 'Content-Type': 'application/json'})
     
     def test_list_webhooks_async(self):
         async def func():
@@ -224,7 +224,7 @@ class TestNotificationAsync(BaseTest):
         data = self.loop.run_until_complete(func())
         
         self.assertIsNotNone(data)
-        self.mock_http.get.assert_called_once_with('http://localhost:5000/notification/webhooks', headers={'X-Idfy-SDK': 'Python {}'.format(version), 'Authorization': 'Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJmb28iOiJiYXIifQ.UIZchxQD36xuhacrJF9HQ5SIUxH5HBiv9noESAacsxU', 'Content-Type': 'application/json'}, params=None)
+        self.mock_http.get.assert_called_once_with('{}/notification/webhooks'.format(self.base_url), headers={'X-Idfy-SDK': 'Python {}'.format(version), 'Authorization': 'Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJmb28iOiJiYXIifQ.UIZchxQD36xuhacrJF9HQ5SIUxH5HBiv9noESAacsxU', 'Content-Type': 'application/json'}, params=None)
 
     def test_create_webhook_async(self):
         async def func():
@@ -232,7 +232,7 @@ class TestNotificationAsync(BaseTest):
         data = self.loop.run_until_complete(func())
         
         self.assertIsNotNone(data)
-        self.mock_http.post.assert_called_once_with('http://localhost:5000/notification/webhooks', auth=None, data='{"unit": "test"}', headers={'X-Idfy-SDK': 'Python {}'.format(version), 'Authorization': 'Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJmb28iOiJiYXIifQ.UIZchxQD36xuhacrJF9HQ5SIUxH5HBiv9noESAacsxU', 'Content-Type': 'application/json'}, params=None)
+        self.mock_http.post.assert_called_once_with('{}/notification/webhooks'.format(self.base_url), auth=None, data='{"unit": "test"}', headers={'X-Idfy-SDK': 'Python {}'.format(version), 'Authorization': 'Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJmb28iOiJiYXIifQ.UIZchxQD36xuhacrJF9HQ5SIUxH5HBiv9noESAacsxU', 'Content-Type': 'application/json'}, params=None)
     
     def test_ping_webhook_async(self):
         async def func():
@@ -240,7 +240,7 @@ class TestNotificationAsync(BaseTest):
         data = self.loop.run_until_complete(func())
         
         self.assertIsNotNone(data)
-        self.mock_http.post.assert_called_once_with('http://localhost:5000/notification/webhooks/1/ping', auth=None, data='null', headers={'X-Idfy-SDK': 'Python {}'.format(version), 'Authorization': 'Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJmb28iOiJiYXIifQ.UIZchxQD36xuhacrJF9HQ5SIUxH5HBiv9noESAacsxU', 'Content-Type': 'application/json'}, params=None)
+        self.mock_http.post.assert_called_once_with('{}/notification/webhooks/1/ping'.format(self.base_url), auth=None, data='null', headers={'X-Idfy-SDK': 'Python {}'.format(version), 'Authorization': 'Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJmb28iOiJiYXIifQ.UIZchxQD36xuhacrJF9HQ5SIUxH5HBiv9noESAacsxU', 'Content-Type': 'application/json'}, params=None)
     
     def test_list_webhook_deliveries_async(self):
         async def func():
@@ -248,4 +248,4 @@ class TestNotificationAsync(BaseTest):
         data = self.loop.run_until_complete(func())
         
         self.assertIsNotNone(data)
-        self.mock_http.get.assert_called_once_with('http://localhost:5000/notification/webhooks/1/deliveries', headers={'X-Idfy-SDK': 'Python {}'.format(version), 'Authorization': 'Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJmb28iOiJiYXIifQ.UIZchxQD36xuhacrJF9HQ5SIUxH5HBiv9noESAacsxU', 'Content-Type': 'application/json'}, params=None)
+        self.mock_http.get.assert_called_once_with('{}/notification/webhooks/1/deliveries'.format(self.base_url), headers={'X-Idfy-SDK': 'Python {}'.format(version), 'Authorization': 'Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJmb28iOiJiYXIifQ.UIZchxQD36xuhacrJF9HQ5SIUxH5HBiv9noESAacsxU', 'Content-Type': 'application/json'}, params=None)

--- a/test/test_services/test_signature.py
+++ b/test/test_services/test_signature.py
@@ -18,14 +18,14 @@ class TestSignature(BaseTest):
 
         self.assertIsNotNone(data)
         self.assertEqual(data.description, 'This is an important document')
-        self.mock_http.get.assert_called_once_with('http://localhost:5000/signature/documents/123', headers={'X-Idfy-SDK': 'Python {}'.format(version), 'Authorization': 'Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJmb28iOiJiYXIifQ.UIZchxQD36xuhacrJF9HQ5SIUxH5HBiv9noESAacsxU', 'Content-Type': 'application/json'}, params=None)
+        self.mock_http.get.assert_called_once_with('{}/signature/documents/123'.format(self.base_url), headers={'X-Idfy-SDK': 'Python {}'.format(version), 'Authorization': 'Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJmb28iOiJiYXIifQ.UIZchxQD36xuhacrJF9HQ5SIUxH5HBiv9noESAacsxU', 'Content-Type': 'application/json'}, params=None)
 
     def test_create_document(self):
         data = self.signature_service.create_document(options=self.params)
         
         self.assertIsNotNone(data)
         self.assertEqual(data.document_id, "94865b6f-2aa9-436d-8b3c-a85e00efd034")
-        self.mock_http.post.assert_called_with('http://localhost:5000/signature/documents', auth=None, data='{"unit": "test"}', headers={'X-Idfy-SDK': 'Python {}'.format(version), 'Authorization': 'Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJmb28iOiJiYXIifQ.UIZchxQD36xuhacrJF9HQ5SIUxH5HBiv9noESAacsxU', 'Content-Type': 'application/json'}, params=None)
+        self.mock_http.post.assert_called_with('{}/signature/documents'.format(self.base_url), auth=None, data='{"unit": "test"}', headers={'X-Idfy-SDK': 'Python {}'.format(version), 'Authorization': 'Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJmb28iOiJiYXIifQ.UIZchxQD36xuhacrJF9HQ5SIUxH5HBiv9noESAacsxU', 'Content-Type': 'application/json'}, params=None)
         self.assertEqual(self.mock_http.post.call_count, 1)
 
     def test_update_document(self):
@@ -33,13 +33,13 @@ class TestSignature(BaseTest):
         
         self.assertIsNotNone(data)
         self.assertEqual(data.title, "Updated title")
-        self.mock_http.patch.assert_called_once_with('http://localhost:5000/signature/documents/123', data='null', headers={'X-Idfy-SDK': 'Python {}'.format(version), 'Authorization': 'Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJmb28iOiJiYXIifQ.UIZchxQD36xuhacrJF9HQ5SIUxH5HBiv9noESAacsxU', 'Content-Type': 'application/json'})
+        self.mock_http.patch.assert_called_once_with('{}/signature/documents/123'.format(self.base_url), data='null', headers={'X-Idfy-SDK': 'Python {}'.format(version), 'Authorization': 'Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJmb28iOiJiYXIifQ.UIZchxQD36xuhacrJF9HQ5SIUxH5HBiv9noESAacsxU', 'Content-Type': 'application/json'})
 
     def test_cancel_document(self):
         data = self.signature_service.cancel_document(document_id="123", reason="test")
         
         self.assertIsNone(data)
-        self.mock_http.post.assert_called_with('http://localhost:5000/signature/documents/123/cancel', auth=None, data='null', headers={'X-Idfy-SDK': 'Python {}'.format(version), 'Authorization': 'Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJmb28iOiJiYXIifQ.UIZchxQD36xuhacrJF9HQ5SIUxH5HBiv9noESAacsxU', 'Content-Type': 'application/json'}, params='test')
+        self.mock_http.post.assert_called_with('{}/signature/documents/123/cancel'.format(self.base_url), auth=None, data='null', headers={'X-Idfy-SDK': 'Python {}'.format(version), 'Authorization': 'Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJmb28iOiJiYXIifQ.UIZchxQD36xuhacrJF9HQ5SIUxH5HBiv9noESAacsxU', 'Content-Type': 'application/json'}, params='test')
         self.assertEqual(self.mock_http.post.call_count, 1)
 
     def test_get_document_status(self):
@@ -47,7 +47,7 @@ class TestSignature(BaseTest):
         
         self.assertIsNotNone(data)
         self.assertEqual(data.document_status, "signed")
-        self.mock_http.get.assert_called_once_with('http://localhost:5000/signature/documents/123/status', headers={'X-Idfy-SDK': 'Python {}'.format(version), 'Authorization': 'Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJmb28iOiJiYXIifQ.UIZchxQD36xuhacrJF9HQ5SIUxH5HBiv9noESAacsxU', 'Content-Type': 'application/json'}, params=None)
+        self.mock_http.get.assert_called_once_with('{}/signature/documents/123/status'.format(self.base_url), headers={'X-Idfy-SDK': 'Python {}'.format(version), 'Authorization': 'Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJmb28iOiJiYXIifQ.UIZchxQD36xuhacrJF9HQ5SIUxH5HBiv9noESAacsxU', 'Content-Type': 'application/json'}, params=None)
         self.assertEqual(self.mock_http.get.call_count, 1)
 
     def test_get_document_summary(self):
@@ -55,7 +55,7 @@ class TestSignature(BaseTest):
         
         self.assertIsNotNone(data)
         #self.assertEqual(data.account_id, "098f63e6-497f-4b42-b3f7-59015df7c762")
-        self.mock_http.get.assert_called_once_with('http://localhost:5000/signature/documents/123/summary', headers={'X-Idfy-SDK': 'Python {}'.format(version), 'Authorization': 'Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJmb28iOiJiYXIifQ.UIZchxQD36xuhacrJF9HQ5SIUxH5HBiv9noESAacsxU', 'Content-Type': 'application/json'}, params=None)
+        self.mock_http.get.assert_called_once_with('{}/signature/documents/123/summary'.format(self.base_url), headers={'X-Idfy-SDK': 'Python {}'.format(version), 'Authorization': 'Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJmb28iOiJiYXIifQ.UIZchxQD36xuhacrJF9HQ5SIUxH5HBiv9noESAacsxU', 'Content-Type': 'application/json'}, params=None)
         self.assertEqual(self.mock_http.get.call_count, 1)
     
     
@@ -64,7 +64,7 @@ class TestSignature(BaseTest):
         
         self.assertIsNotNone(data)
         self.assertEqual(data.size, 45)
-        self.mock_http.get.assert_called_once_with('http://localhost:5000/signature/documents/summary', headers={'X-Idfy-SDK': 'Python {}'.format(version), 'Authorization': 'Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJmb28iOiJiYXIifQ.UIZchxQD36xuhacrJF9HQ5SIUxH5HBiv9noESAacsxU', 'Content-Type': 'application/json'}, params={'externalId': None, 'signerId': None, 'externalSignerId': None, 'fromDate': None, 'toDate': None, 'lastUpdated': None, 'signedDate': None, 'nameOfSigner': None, 'title': None, 'status': None, 'tags': None, 'offset': None, 'limit': None})
+        self.mock_http.get.assert_called_once_with('{}/signature/documents/summary'.format(self.base_url), headers={'X-Idfy-SDK': 'Python {}'.format(version), 'Authorization': 'Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJmb28iOiJiYXIifQ.UIZchxQD36xuhacrJF9HQ5SIUxH5HBiv9noESAacsxU', 'Content-Type': 'application/json'}, params={'externalId': None, 'signerId': None, 'externalSignerId': None, 'fromDate': None, 'toDate': None, 'lastUpdated': None, 'signedDate': None, 'nameOfSigner': None, 'title': None, 'status': None, 'tags': None, 'offset': None, 'limit': None})
         self.assertEqual(self.mock_http.get.call_count, 1)
     
     #Signers
@@ -73,7 +73,7 @@ class TestSignature(BaseTest):
         
         self.assertIsNotNone(data)
         self.assertEqual(data.url, "https://sign-test.idfy.io/init?jwt=...")
-        self.mock_http.get.assert_called_once_with('http://localhost:5000/signature/documents/123/signers/123', headers={'X-Idfy-SDK': 'Python {}'.format(version), 'Authorization': 'Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJmb28iOiJiYXIifQ.UIZchxQD36xuhacrJF9HQ5SIUxH5HBiv9noESAacsxU', 'Content-Type': 'application/json'}, params=None)
+        self.mock_http.get.assert_called_once_with('{}/signature/documents/123/signers/123'.format(self.base_url), headers={'X-Idfy-SDK': 'Python {}'.format(version), 'Authorization': 'Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJmb28iOiJiYXIifQ.UIZchxQD36xuhacrJF9HQ5SIUxH5HBiv9noESAacsxU', 'Content-Type': 'application/json'}, params=None)
         self.assertEqual(self.mock_http.get.call_count, 1)
     
     def test_create_signer(self):
@@ -81,7 +81,7 @@ class TestSignature(BaseTest):
         
         self.assertIsNotNone(data)
         self.assertEqual(data.external_signer_id, "aoijfnmo032q223")
-        self.mock_http.post.assert_called_once_with('http://localhost:5000/signature/documents/123/signers', auth=None, data='{"unit": "test"}', headers={'X-Idfy-SDK': 'Python {}'.format(version), 'Authorization': 'Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJmb28iOiJiYXIifQ.UIZchxQD36xuhacrJF9HQ5SIUxH5HBiv9noESAacsxU', 'Content-Type': 'application/json'}, params=None)
+        self.mock_http.post.assert_called_once_with('{}/signature/documents/123/signers'.format(self.base_url), auth=None, data='{"unit": "test"}', headers={'X-Idfy-SDK': 'Python {}'.format(version), 'Authorization': 'Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJmb28iOiJiYXIifQ.UIZchxQD36xuhacrJF9HQ5SIUxH5HBiv9noESAacsxU', 'Content-Type': 'application/json'}, params=None)
         self.assertEqual(self.mock_http.post.call_count, 1)
     
     def test_update_signer(self):
@@ -89,7 +89,7 @@ class TestSignature(BaseTest):
         
         self.assertIsNotNone(data)
         self.assertEqual(data.signer_info.first_name, "Updated")
-        self.mock_http.patch.assert_called_once_with('http://localhost:5000/signature/documents/123/signers/456', data='{"unit": "test"}', headers={'X-Idfy-SDK': 'Python {}'.format(version), 'Authorization': 'Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJmb28iOiJiYXIifQ.UIZchxQD36xuhacrJF9HQ5SIUxH5HBiv9noESAacsxU', 'Content-Type': 'application/json'})
+        self.mock_http.patch.assert_called_once_with('{}/signature/documents/123/signers/456'.format(self.base_url), data='{"unit": "test"}', headers={'X-Idfy-SDK': 'Python {}'.format(version), 'Authorization': 'Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJmb28iOiJiYXIifQ.UIZchxQD36xuhacrJF9HQ5SIUxH5HBiv9noESAacsxU', 'Content-Type': 'application/json'})
         self.assertEqual(self.mock_http.patch.call_count, 1)
     
     def test_delete_signer(self):
@@ -97,7 +97,7 @@ class TestSignature(BaseTest):
     
         self.assertIsNone(data)
         #self.assertEqual()
-        self.mock_http.delete.assert_called_once_with('http://localhost:5000/signature/documents/123/signers/456', headers={'X-Idfy-SDK': 'Python {}'.format(version), 'Authorization': 'Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJmb28iOiJiYXIifQ.UIZchxQD36xuhacrJF9HQ5SIUxH5HBiv9noESAacsxU', 'Content-Type': 'application/json'})
+        self.mock_http.delete.assert_called_once_with('{}/signature/documents/123/signers/456'.format(self.base_url), headers={'X-Idfy-SDK': 'Python {}'.format(version), 'Authorization': 'Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJmb28iOiJiYXIifQ.UIZchxQD36xuhacrJF9HQ5SIUxH5HBiv9noESAacsxU', 'Content-Type': 'application/json'})
         self.assertEqual(self.mock_http.delete.call_count, 1)
         
     
@@ -106,7 +106,7 @@ class TestSignature(BaseTest):
         
         self.assertIsNotNone(data)
         #self.assertEqual()
-        self.mock_http.get.assert_called_once_with('http://localhost:5000/signature/documents/123/signers/', headers={'X-Idfy-SDK': 'Python {}'.format(version), 'Authorization': 'Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJmb28iOiJiYXIifQ.UIZchxQD36xuhacrJF9HQ5SIUxH5HBiv9noESAacsxU', 'Content-Type': 'application/json'}, params=None)
+        self.mock_http.get.assert_called_once_with('{}/signature/documents/123/signers/'.format(self.base_url), headers={'X-Idfy-SDK': 'Python {}'.format(version), 'Authorization': 'Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJmb28iOiJiYXIifQ.UIZchxQD36xuhacrJF9HQ5SIUxH5HBiv9noESAacsxU', 'Content-Type': 'application/json'}, params=None)
         self.assertEqual(self.mock_http.get.call_count, 1)
 
     def test_get_attachment(self):
@@ -114,7 +114,7 @@ class TestSignature(BaseTest):
         
         self.assertIsNotNone(data)
         #self.assertEqual()
-        self.mock_http.get.assert_called_once_with('http://localhost:5000/signature/documents/1/attachments/2', headers={'X-Idfy-SDK': 'Python {}'.format(version), 'Authorization': 'Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJmb28iOiJiYXIifQ.UIZchxQD36xuhacrJF9HQ5SIUxH5HBiv9noESAacsxU', 'Content-Type': 'application/json'}, params=None)
+        self.mock_http.get.assert_called_once_with('{}/signature/documents/1/attachments/2'.format(self.base_url), headers={'X-Idfy-SDK': 'Python {}'.format(version), 'Authorization': 'Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJmb28iOiJiYXIifQ.UIZchxQD36xuhacrJF9HQ5SIUxH5HBiv9noESAacsxU', 'Content-Type': 'application/json'}, params=None)
         self.assertEqual(self.mock_http.get.call_count, 1)
     
     def test_create_attachment(self):
@@ -122,7 +122,7 @@ class TestSignature(BaseTest):
         
         self.assertIsNotNone(data)
         #self.assertEqual()
-        self.mock_http.post.assert_called_once_with('http://localhost:5000/signature/documents/1/attachments/', auth=None, data='{"unit": "test"}', headers={'X-Idfy-SDK': 'Python {}'.format(version), 'Authorization': 'Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJmb28iOiJiYXIifQ.UIZchxQD36xuhacrJF9HQ5SIUxH5HBiv9noESAacsxU', 'Content-Type': 'application/json'}, params=None)
+        self.mock_http.post.assert_called_once_with('{}/signature/documents/1/attachments/'.format(self.base_url), auth=None, data='{"unit": "test"}', headers={'X-Idfy-SDK': 'Python {}'.format(version), 'Authorization': 'Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJmb28iOiJiYXIifQ.UIZchxQD36xuhacrJF9HQ5SIUxH5HBiv9noESAacsxU', 'Content-Type': 'application/json'}, params=None)
         self.assertEqual(self.mock_http.post.call_count, 1)
     
     def test_update_attachment(self):
@@ -130,7 +130,7 @@ class TestSignature(BaseTest):
     
         self.assertIsNotNone(data)
         #self.assertEqual()
-        self.mock_http.patch.assert_called_once_with('http://localhost:5000/signature/documents/1/attachments/2', data='{"unit": "test"}', headers={'X-Idfy-SDK': 'Python {}'.format(version), 'Authorization': 'Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJmb28iOiJiYXIifQ.UIZchxQD36xuhacrJF9HQ5SIUxH5HBiv9noESAacsxU', 'Content-Type': 'application/json'})
+        self.mock_http.patch.assert_called_once_with('{}/signature/documents/1/attachments/2'.format(self.base_url), data='{"unit": "test"}', headers={'X-Idfy-SDK': 'Python {}'.format(version), 'Authorization': 'Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJmb28iOiJiYXIifQ.UIZchxQD36xuhacrJF9HQ5SIUxH5HBiv9noESAacsxU', 'Content-Type': 'application/json'})
         self.assertEqual(self.mock_http.patch.call_count, 1)
 
     def test_delete_attachment(self): # Not "tested" yet.
@@ -138,7 +138,7 @@ class TestSignature(BaseTest):
         
         self.assertIsNone(data)
         #self.assertEqual()
-        self.mock_http.delete.assert_called_once_with('http://localhost:5000/signature/documents/1/attachments/1', headers={'X-Idfy-SDK': 'Python {}'.format(version), 'Authorization': 'Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJmb28iOiJiYXIifQ.UIZchxQD36xuhacrJF9HQ5SIUxH5HBiv9noESAacsxU', 'Content-Type': 'application/json'})
+        self.mock_http.delete.assert_called_once_with('{}/signature/documents/1/attachments/1'.format(self.base_url), headers={'X-Idfy-SDK': 'Python {}'.format(version), 'Authorization': 'Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJmb28iOiJiYXIifQ.UIZchxQD36xuhacrJF9HQ5SIUxH5HBiv9noESAacsxU', 'Content-Type': 'application/json'})
         self.assertEqual(self.mock_http.delete.call_count, 1)
 
     def test_list_attachments(self):
@@ -146,7 +146,7 @@ class TestSignature(BaseTest):
         
         self.assertIsNotNone(data)
         #self.assertEqual()
-        self.mock_http.get.assert_called_once_with('http://localhost:5000/signature/documents/1/attachments', headers={'X-Idfy-SDK': 'Python {}'.format(version), 'Authorization': 'Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJmb28iOiJiYXIifQ.UIZchxQD36xuhacrJF9HQ5SIUxH5HBiv9noESAacsxU', 'Content-Type': 'application/json'}, params=None)
+        self.mock_http.get.assert_called_once_with('{}/signature/documents/1/attachments'.format(self.base_url), headers={'X-Idfy-SDK': 'Python {}'.format(version), 'Authorization': 'Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJmb28iOiJiYXIifQ.UIZchxQD36xuhacrJF9HQ5SIUxH5HBiv9noESAacsxU', 'Content-Type': 'application/json'}, params=None)
         self.assertEqual(self.mock_http.get.call_count, 1)
 
     def test_get_file(self):
@@ -154,7 +154,7 @@ class TestSignature(BaseTest):
         
         self.assertIsNotNone(data)
         #self.assertEqual()
-        self.mock_http.get.assert_called_once_with('http://localhost:5000/signature/documents/1/files', headers={'X-Idfy-SDK': 'Python {}'.format(version), 'Authorization': 'Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJmb28iOiJiYXIifQ.UIZchxQD36xuhacrJF9HQ5SIUxH5HBiv9noESAacsxU', 'Content-Type': 'application/json'}, params='2')
+        self.mock_http.get.assert_called_once_with('{}/signature/documents/1/files'.format(self.base_url), headers={'X-Idfy-SDK': 'Python {}'.format(version), 'Authorization': 'Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJmb28iOiJiYXIifQ.UIZchxQD36xuhacrJF9HQ5SIUxH5HBiv9noESAacsxU', 'Content-Type': 'application/json'}, params='2')
         self.assertEqual(self.mock_http.get.call_count, 1)
 
     def test_get_file_for_signer(self):
@@ -162,7 +162,7 @@ class TestSignature(BaseTest):
         
         self.assertIsNotNone(data)
         #self.assertEqual()
-        self.mock_http.get.assert_called_once_with('http://localhost:5000/signature/documents/1/files/signers/2', headers={'X-Idfy-SDK': 'Python {}'.format(version), 'Authorization': 'Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJmb28iOiJiYXIifQ.UIZchxQD36xuhacrJF9HQ5SIUxH5HBiv9noESAacsxU', 'Content-Type': 'application/json'}, params='3')
+        self.mock_http.get.assert_called_once_with('{}/signature/documents/1/files/signers/2'.format(self.base_url), headers={'X-Idfy-SDK': 'Python {}'.format(version), 'Authorization': 'Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJmb28iOiJiYXIifQ.UIZchxQD36xuhacrJF9HQ5SIUxH5HBiv9noESAacsxU', 'Content-Type': 'application/json'}, params='3')
         self.assertEqual(self.mock_http.get.call_count, 1)
     
     def test_get_attachment_file(self):
@@ -170,7 +170,7 @@ class TestSignature(BaseTest):
         
         self.assertIsNotNone(data)
         #self.assertEqual()
-        self.mock_http.get.assert_called_once_with('http://localhost:5000/signature/documents/1/files/attachments/2', headers={'X-Idfy-SDK': 'Python {}'.format(version), 'Authorization': 'Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJmb28iOiJiYXIifQ.UIZchxQD36xuhacrJF9HQ5SIUxH5HBiv9noESAacsxU', 'Content-Type': 'application/json'}, params='3')
+        self.mock_http.get.assert_called_once_with('{}/signature/documents/1/files/attachments/2'.format(self.base_url), headers={'X-Idfy-SDK': 'Python {}'.format(version), 'Authorization': 'Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJmb28iOiJiYXIifQ.UIZchxQD36xuhacrJF9HQ5SIUxH5HBiv9noESAacsxU', 'Content-Type': 'application/json'}, params='3')
         self.assertEqual(self.mock_http.get.call_count, 1)
    
     def test_get_attachment_file_for_signer(self):
@@ -178,7 +178,7 @@ class TestSignature(BaseTest):
         
         self.assertIsNotNone(data)
         #self.assertEqual()
-        self.mock_http.get.assert_called_once_with('http://localhost:5000/signature/documents/1/files/attachments/2/signers/3', headers={'X-Idfy-SDK': 'Python {}'.format(version), 'Authorization': 'Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJmb28iOiJiYXIifQ.UIZchxQD36xuhacrJF9HQ5SIUxH5HBiv9noESAacsxU', 'Content-Type': 'application/json'}, params='4')
+        self.mock_http.get.assert_called_once_with('{}/signature/documents/1/files/attachments/2/signers/3'.format(self.base_url), headers={'X-Idfy-SDK': 'Python {}'.format(version), 'Authorization': 'Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJmb28iOiJiYXIifQ.UIZchxQD36xuhacrJF9HQ5SIUxH5HBiv9noESAacsxU', 'Content-Type': 'application/json'}, params='4')
         self.assertEqual(self.mock_http.get.call_count, 1)
 
     def test_list_notifications(self):
@@ -186,7 +186,7 @@ class TestSignature(BaseTest):
         
         self.assertIsNotNone(data)
         #self.assertEqual()
-        self.mock_http.get.assert_called_once_with('http://localhost:5000/signature/documents/1/notifications', headers={'X-Idfy-SDK': 'Python {}'.format(version), 'Authorization': 'Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJmb28iOiJiYXIifQ.UIZchxQD36xuhacrJF9HQ5SIUxH5HBiv9noESAacsxU', 'Content-Type': 'application/json'}, params=None)
+        self.mock_http.get.assert_called_once_with('{}/signature/documents/1/notifications'.format(self.base_url), headers={'X-Idfy-SDK': 'Python {}'.format(version), 'Authorization': 'Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJmb28iOiJiYXIifQ.UIZchxQD36xuhacrJF9HQ5SIUxH5HBiv9noESAacsxU', 'Content-Type': 'application/json'}, params=None)
         self.assertEqual(self.mock_http.get.call_count, 1)
 
     def test_send_reminders(self):
@@ -194,7 +194,7 @@ class TestSignature(BaseTest):
         
         self.assertIsNotNone(data)
         #self.assertEqual()
-        self.mock_http.post.assert_called_once_with('http://localhost:5000/signature/documents/1/notifications/reminder', auth=None, data='{"unit": "test"}', headers={'X-Idfy-SDK': 'Python {}'.format(version), 'Authorization': 'Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJmb28iOiJiYXIifQ.UIZchxQD36xuhacrJF9HQ5SIUxH5HBiv9noESAacsxU', 'Content-Type': 'application/json'}, params=None)
+        self.mock_http.post.assert_called_once_with('{}/signature/documents/1/notifications/reminder'.format(self.base_url), auth=None, data='{"unit": "test"}', headers={'X-Idfy-SDK': 'Python {}'.format(version), 'Authorization': 'Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJmb28iOiJiYXIifQ.UIZchxQD36xuhacrJF9HQ5SIUxH5HBiv9noESAacsxU', 'Content-Type': 'application/json'}, params=None)
         self.assertEqual(self.mock_http.post.call_count, 1)
     
     def test_list_themes(self):
@@ -202,7 +202,7 @@ class TestSignature(BaseTest):
         
         self.assertIsNotNone(data)
         #self.assertEqual()
-        self.mock_http.get.assert_called_once_with('http://localhost:5000/signature/themes/list/themes', headers={'X-Idfy-SDK': 'Python {}'.format(version), 'Authorization': 'Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJmb28iOiJiYXIifQ.UIZchxQD36xuhacrJF9HQ5SIUxH5HBiv9noESAacsxU', 'Content-Type': 'application/json'}, params=None)
+        self.mock_http.get.assert_called_once_with('{}/signature/themes/list/themes'.format(self.base_url), headers={'X-Idfy-SDK': 'Python {}'.format(version), 'Authorization': 'Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJmb28iOiJiYXIifQ.UIZchxQD36xuhacrJF9HQ5SIUxH5HBiv9noESAacsxU', 'Content-Type': 'application/json'}, params=None)
         self.assertEqual(self.mock_http.get.call_count, 1)
     
     def test_list_spinners(self):
@@ -210,7 +210,7 @@ class TestSignature(BaseTest):
         
         self.assertIsNotNone(data)
         #self.assertEqual()
-        self.mock_http.get.assert_called_once_with('http://localhost:5000/signature/themes/list/spinners', headers={'X-Idfy-SDK': 'Python {}'.format(version), 'Authorization': 'Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJmb28iOiJiYXIifQ.UIZchxQD36xuhacrJF9HQ5SIUxH5HBiv9noESAacsxU', 'Content-Type': 'application/json'}, params=None)
+        self.mock_http.get.assert_called_once_with('{}/signature/themes/list/spinners'.format(self.base_url), headers={'X-Idfy-SDK': 'Python {}'.format(version), 'Authorization': 'Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJmb28iOiJiYXIifQ.UIZchxQD36xuhacrJF9HQ5SIUxH5HBiv9noESAacsxU', 'Content-Type': 'application/json'}, params=None)
         self.assertEqual(self.mock_http.get.call_count, 1)
 
 class TestSignatureAsync(BaseTest):
@@ -236,7 +236,7 @@ class TestSignatureAsync(BaseTest):
 
         self.assertIsNotNone(data)
         self.assertEqual(data.signers[0].external_signer_id, 'uoiahsd321982983jhrmnec2wsadm32')
-        self.mock_http.get.assert_called_once_with('http://localhost:5000/signature/documents/123', headers={'X-Idfy-SDK': 'Python {}'.format(version), 'Authorization': 'Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJmb28iOiJiYXIifQ.UIZchxQD36xuhacrJF9HQ5SIUxH5HBiv9noESAacsxU', 'Content-Type': 'application/json'}, params=None)
+        self.mock_http.get.assert_called_once_with('{}/signature/documents/123'.format(self.base_url), headers={'X-Idfy-SDK': 'Python {}'.format(version), 'Authorization': 'Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJmb28iOiJiYXIifQ.UIZchxQD36xuhacrJF9HQ5SIUxH5HBiv9noESAacsxU', 'Content-Type': 'application/json'}, params=None)
         self.assertEqual(self.mock_http.get.call_count, 1)
 
     def test_create_document_async(self):
@@ -246,7 +246,7 @@ class TestSignatureAsync(BaseTest):
         
         self.assertIsNotNone(data)
         self.assertEqual(data.document_id, "94865b6f-2aa9-436d-8b3c-a85e00efd034") 
-        self.mock_http.post.assert_called_once_with('http://localhost:5000/signature/documents', auth=None, data='{"unit": "test"}', headers={'X-Idfy-SDK': 'Python {}'.format(version), 'Authorization': 'Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJmb28iOiJiYXIifQ.UIZchxQD36xuhacrJF9HQ5SIUxH5HBiv9noESAacsxU', 'Content-Type': 'application/json'}, params=None)
+        self.mock_http.post.assert_called_once_with('{}/signature/documents'.format(self.base_url), auth=None, data='{"unit": "test"}', headers={'X-Idfy-SDK': 'Python {}'.format(version), 'Authorization': 'Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJmb28iOiJiYXIifQ.UIZchxQD36xuhacrJF9HQ5SIUxH5HBiv9noESAacsxU', 'Content-Type': 'application/json'}, params=None)
         self.assertEqual(self.mock_http.post.call_count, 1)
  
     def test_update_document_async(self):
@@ -256,7 +256,7 @@ class TestSignatureAsync(BaseTest):
         
         self.assertIsNotNone(data)
         #self.assertEqual() 
-        self.mock_http.patch.assert_called_once_with('http://localhost:5000/signature/documents/123', data='null', headers={'X-Idfy-SDK': 'Python {}'.format(version), 'Authorization': 'Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJmb28iOiJiYXIifQ.UIZchxQD36xuhacrJF9HQ5SIUxH5HBiv9noESAacsxU', 'Content-Type': 'application/json'})
+        self.mock_http.patch.assert_called_once_with('{}/signature/documents/123'.format(self.base_url), data='null', headers={'X-Idfy-SDK': 'Python {}'.format(version), 'Authorization': 'Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJmb28iOiJiYXIifQ.UIZchxQD36xuhacrJF9HQ5SIUxH5HBiv9noESAacsxU', 'Content-Type': 'application/json'})
         self.assertEqual(self.mock_http.patch.call_count, 1)
 
 
@@ -267,7 +267,7 @@ class TestSignatureAsync(BaseTest):
         
         
         self.assertEqual(data, '""')
-        self.mock_http.post.assert_called_with('http://localhost:5000/signature/documents/123/cancel', auth=None, data='null', headers={'X-Idfy-SDK': 'Python {}'.format(version), 'Authorization': 'Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJmb28iOiJiYXIifQ.UIZchxQD36xuhacrJF9HQ5SIUxH5HBiv9noESAacsxU', 'Content-Type': 'application/json'}, params='test')
+        self.mock_http.post.assert_called_with('{}/signature/documents/123/cancel'.format(self.base_url), auth=None, data='null', headers={'X-Idfy-SDK': 'Python {}'.format(version), 'Authorization': 'Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJmb28iOiJiYXIifQ.UIZchxQD36xuhacrJF9HQ5SIUxH5HBiv9noESAacsxU', 'Content-Type': 'application/json'}, params='test')
         self.assertEqual(self.mock_http.post.call_count, 1)
     
     def test_get_document_status_async(self):
@@ -278,7 +278,7 @@ class TestSignatureAsync(BaseTest):
         
         self.assertIsNotNone(data)
         self.assertEqual(data.document_status, "signed")
-        self.mock_http.get.assert_called_once_with('http://localhost:5000/signature/documents/123/status', headers={'X-Idfy-SDK': 'Python {}'.format(version), 'Authorization': 'Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJmb28iOiJiYXIifQ.UIZchxQD36xuhacrJF9HQ5SIUxH5HBiv9noESAacsxU', 'Content-Type': 'application/json'}, params=None)
+        self.mock_http.get.assert_called_once_with('{}/signature/documents/123/status'.format(self.base_url), headers={'X-Idfy-SDK': 'Python {}'.format(version), 'Authorization': 'Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJmb28iOiJiYXIifQ.UIZchxQD36xuhacrJF9HQ5SIUxH5HBiv9noESAacsxU', 'Content-Type': 'application/json'}, params=None)
         self.assertEqual(self.mock_http.get.call_count, 1)
     
     def test_get_document_summary_async(self):
@@ -289,7 +289,7 @@ class TestSignatureAsync(BaseTest):
         
         self.assertIsNotNone(data)
         #self.assertEqual(data.account_id, "098f63e6-497f-4b42-b3f7-59015df7c762")
-        self.mock_http.get.assert_called_once_with('http://localhost:5000/signature/documents/123/summary', headers={'X-Idfy-SDK': 'Python {}'.format(version), 'Authorization': 'Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJmb28iOiJiYXIifQ.UIZchxQD36xuhacrJF9HQ5SIUxH5HBiv9noESAacsxU', 'Content-Type': 'application/json'}, params=None)
+        self.mock_http.get.assert_called_once_with('{}/signature/documents/123/summary'.format(self.base_url), headers={'X-Idfy-SDK': 'Python {}'.format(version), 'Authorization': 'Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJmb28iOiJiYXIifQ.UIZchxQD36xuhacrJF9HQ5SIUxH5HBiv9noESAacsxU', 'Content-Type': 'application/json'}, params=None)
         self.assertEqual(self.mock_http.get.call_count, 1)
     
     def test_list_document_summaries_async(self):
@@ -300,7 +300,7 @@ class TestSignatureAsync(BaseTest):
         
         self.assertIsNotNone(data)
         self.assertEqual(data.size, 45)
-        self.mock_http.get.assert_called_once_with('http://localhost:5000/signature/documents/summary', headers={'X-Idfy-SDK': 'Python {}'.format(version), 'Authorization': 'Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJmb28iOiJiYXIifQ.UIZchxQD36xuhacrJF9HQ5SIUxH5HBiv9noESAacsxU', 'Content-Type': 'application/json'}, params={'externalId': None, 'signerId': None, 'externalSignerId': None, 'fromDate': None, 'toDate': None, 'lastUpdated': None, 'signedDate': None, 'nameOfSigner': None, 'title': None, 'status': None, 'tags': None, 'offset': None, 'limit': None})
+        self.mock_http.get.assert_called_once_with('{}/signature/documents/summary'.format(self.base_url), headers={'X-Idfy-SDK': 'Python {}'.format(version), 'Authorization': 'Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJmb28iOiJiYXIifQ.UIZchxQD36xuhacrJF9HQ5SIUxH5HBiv9noESAacsxU', 'Content-Type': 'application/json'}, params={'externalId': None, 'signerId': None, 'externalSignerId': None, 'fromDate': None, 'toDate': None, 'lastUpdated': None, 'signedDate': None, 'nameOfSigner': None, 'title': None, 'status': None, 'tags': None, 'offset': None, 'limit': None})
         self.assertEqual(self.mock_http.get.call_count, 1)
     
     #Signers
@@ -312,7 +312,7 @@ class TestSignatureAsync(BaseTest):
         
         self.assertIsNotNone(data)
         self.assertEqual(data.url, "https://sign-test.idfy.io/init?jwt=...")
-        self.mock_http.get.assert_called_once_with('http://localhost:5000/signature/documents/123/signers/123', headers={'X-Idfy-SDK': 'Python {}'.format(version), 'Authorization': 'Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJmb28iOiJiYXIifQ.UIZchxQD36xuhacrJF9HQ5SIUxH5HBiv9noESAacsxU', 'Content-Type': 'application/json'}, params=None)
+        self.mock_http.get.assert_called_once_with('{}/signature/documents/123/signers/123'.format(self.base_url), headers={'X-Idfy-SDK': 'Python {}'.format(version), 'Authorization': 'Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJmb28iOiJiYXIifQ.UIZchxQD36xuhacrJF9HQ5SIUxH5HBiv9noESAacsxU', 'Content-Type': 'application/json'}, params=None)
         self.assertEqual(self.mock_http.get.call_count, 1)
     
     def test_create_signer_async(self):
@@ -323,7 +323,7 @@ class TestSignatureAsync(BaseTest):
         
         self.assertIsNotNone(data)
         self.assertEqual(data.external_signer_id, "aoijfnmo032q223")
-        self.mock_http.post.assert_called_once_with('http://localhost:5000/signature/documents/123/signers', auth=None, data='{"unit": "test"}', headers={'X-Idfy-SDK': 'Python {}'.format(version), 'Authorization': 'Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJmb28iOiJiYXIifQ.UIZchxQD36xuhacrJF9HQ5SIUxH5HBiv9noESAacsxU', 'Content-Type': 'application/json'}, params=None)
+        self.mock_http.post.assert_called_once_with('{}/signature/documents/123/signers'.format(self.base_url), auth=None, data='{"unit": "test"}', headers={'X-Idfy-SDK': 'Python {}'.format(version), 'Authorization': 'Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJmb28iOiJiYXIifQ.UIZchxQD36xuhacrJF9HQ5SIUxH5HBiv9noESAacsxU', 'Content-Type': 'application/json'}, params=None)
         self.assertEqual(self.mock_http.post.call_count, 1)
 
     def test_update_signer_async(self):
@@ -334,7 +334,7 @@ class TestSignatureAsync(BaseTest):
         
         self.assertIsNotNone(data)
         self.assertEqual(data.signer_info.first_name, "Updated")
-        self.mock_http.patch.assert_called_once_with('http://localhost:5000/signature/documents/123/signers/456', data='{"unit": "test"}', headers={'X-Idfy-SDK': 'Python {}'.format(version), 'Authorization': 'Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJmb28iOiJiYXIifQ.UIZchxQD36xuhacrJF9HQ5SIUxH5HBiv9noESAacsxU', 'Content-Type': 'application/json'})
+        self.mock_http.patch.assert_called_once_with('{}/signature/documents/123/signers/456'.format(self.base_url), data='{"unit": "test"}', headers={'X-Idfy-SDK': 'Python {}'.format(version), 'Authorization': 'Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJmb28iOiJiYXIifQ.UIZchxQD36xuhacrJF9HQ5SIUxH5HBiv9noESAacsxU', 'Content-Type': 'application/json'})
         self.assertEqual(self.mock_http.patch.call_count, 1)
     
     def test_delete_signer_async(self):
@@ -344,7 +344,7 @@ class TestSignatureAsync(BaseTest):
         
         self.assertIsNone(data)
         #self.assertEqual()
-        self.mock_http.delete.assert_called_once_with('http://localhost:5000/signature/documents/123/signers/456', headers={'X-Idfy-SDK': 'Python {}'.format(version), 'Authorization': 'Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJmb28iOiJiYXIifQ.UIZchxQD36xuhacrJF9HQ5SIUxH5HBiv9noESAacsxU', 'Content-Type': 'application/json'})
+        self.mock_http.delete.assert_called_once_with('{}/signature/documents/123/signers/456'.format(self.base_url), headers={'X-Idfy-SDK': 'Python {}'.format(version), 'Authorization': 'Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJmb28iOiJiYXIifQ.UIZchxQD36xuhacrJF9HQ5SIUxH5HBiv9noESAacsxU', 'Content-Type': 'application/json'})
         self.assertEqual(self.mock_http.delete.call_count, 1)
     
     def test_list_signers_async(self):
@@ -355,7 +355,7 @@ class TestSignatureAsync(BaseTest):
         
         self.assertIsNotNone(data)
         #self.assertEqual()
-        self.mock_http.get.assert_called_once_with('http://localhost:5000/signature/documents/123/signers/', headers={'X-Idfy-SDK': 'Python {}'.format(version), 'Authorization': 'Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJmb28iOiJiYXIifQ.UIZchxQD36xuhacrJF9HQ5SIUxH5HBiv9noESAacsxU', 'Content-Type': 'application/json'}, params=None)
+        self.mock_http.get.assert_called_once_with('{}/signature/documents/123/signers/'.format(self.base_url), headers={'X-Idfy-SDK': 'Python {}'.format(version), 'Authorization': 'Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJmb28iOiJiYXIifQ.UIZchxQD36xuhacrJF9HQ5SIUxH5HBiv9noESAacsxU', 'Content-Type': 'application/json'}, params=None)
         self.assertEqual(self.mock_http.get.call_count, 1)
     
     def test_get_attachment_async(self):
@@ -366,7 +366,7 @@ class TestSignatureAsync(BaseTest):
         
         self.assertIsNotNone(data)
         #self.assertEqual()
-        self.mock_http.get.assert_called_once_with('http://localhost:5000/signature/documents/1/attachments/2', headers={'X-Idfy-SDK': 'Python {}'.format(version), 'Authorization': 'Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJmb28iOiJiYXIifQ.UIZchxQD36xuhacrJF9HQ5SIUxH5HBiv9noESAacsxU', 'Content-Type': 'application/json'}, params=None)
+        self.mock_http.get.assert_called_once_with('{}/signature/documents/1/attachments/2'.format(self.base_url), headers={'X-Idfy-SDK': 'Python {}'.format(version), 'Authorization': 'Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJmb28iOiJiYXIifQ.UIZchxQD36xuhacrJF9HQ5SIUxH5HBiv9noESAacsxU', 'Content-Type': 'application/json'}, params=None)
         self.assertEqual(self.mock_http.get.call_count, 1)
     
     def test_create_attachment_async(self):
@@ -377,7 +377,7 @@ class TestSignatureAsync(BaseTest):
         
         self.assertIsNotNone(data)
         #self.assertEqual()
-        self.mock_http.post.assert_called_once_with('http://localhost:5000/signature/documents/1/attachments/', auth=None, data='{"unit": "test"}', headers={'X-Idfy-SDK': 'Python {}'.format(version), 'Authorization': 'Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJmb28iOiJiYXIifQ.UIZchxQD36xuhacrJF9HQ5SIUxH5HBiv9noESAacsxU', 'Content-Type': 'application/json'}, params=None)
+        self.mock_http.post.assert_called_once_with('{}/signature/documents/1/attachments/'.format(self.base_url), auth=None, data='{"unit": "test"}', headers={'X-Idfy-SDK': 'Python {}'.format(version), 'Authorization': 'Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJmb28iOiJiYXIifQ.UIZchxQD36xuhacrJF9HQ5SIUxH5HBiv9noESAacsxU', 'Content-Type': 'application/json'}, params=None)
         self.assertEqual(self.mock_http.post.call_count, 1)
     
     def test_update_attachment_async(self):
@@ -388,7 +388,7 @@ class TestSignatureAsync(BaseTest):
     
         self.assertIsNotNone(data)
         #self.assertEqual()
-        self.mock_http.patch.assert_called_once_with('http://localhost:5000/signature/documents/1/attachments/2', data='{"unit": "test"}', headers={'X-Idfy-SDK': 'Python {}'.format(version), 'Authorization': 'Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJmb28iOiJiYXIifQ.UIZchxQD36xuhacrJF9HQ5SIUxH5HBiv9noESAacsxU', 'Content-Type': 'application/json'})
+        self.mock_http.patch.assert_called_once_with('{}/signature/documents/1/attachments/2'.format(self.base_url), data='{"unit": "test"}', headers={'X-Idfy-SDK': 'Python {}'.format(version), 'Authorization': 'Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJmb28iOiJiYXIifQ.UIZchxQD36xuhacrJF9HQ5SIUxH5HBiv9noESAacsxU', 'Content-Type': 'application/json'})
         self.assertEqual(self.mock_http.patch.call_count, 1)
 
     def test_delete_attachment_async(self): # Not "tested" yet.
@@ -399,7 +399,7 @@ class TestSignatureAsync(BaseTest):
         
         self.assertIsNone(data)
         #self.assertEqual()
-        self.mock_http.delete.assert_called_once_with('http://localhost:5000/signature/documents/1/attachments/1', headers={'X-Idfy-SDK': 'Python {}'.format(version), 'Authorization': 'Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJmb28iOiJiYXIifQ.UIZchxQD36xuhacrJF9HQ5SIUxH5HBiv9noESAacsxU', 'Content-Type': 'application/json'})
+        self.mock_http.delete.assert_called_once_with('{}/signature/documents/1/attachments/1'.format(self.base_url), headers={'X-Idfy-SDK': 'Python {}'.format(version), 'Authorization': 'Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJmb28iOiJiYXIifQ.UIZchxQD36xuhacrJF9HQ5SIUxH5HBiv9noESAacsxU', 'Content-Type': 'application/json'})
         self.assertEqual(self.mock_http.delete.call_count, 1)
     
 
@@ -411,7 +411,7 @@ class TestSignatureAsync(BaseTest):
         
         self.assertIsNotNone(data)
         #self.assertEqual()
-        self.mock_http.get.assert_called_once_with('http://localhost:5000/signature/documents/1/attachments', headers={'X-Idfy-SDK': 'Python {}'.format(version), 'Authorization': 'Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJmb28iOiJiYXIifQ.UIZchxQD36xuhacrJF9HQ5SIUxH5HBiv9noESAacsxU', 'Content-Type': 'application/json'}, params=None)
+        self.mock_http.get.assert_called_once_with('{}/signature/documents/1/attachments'.format(self.base_url), headers={'X-Idfy-SDK': 'Python {}'.format(version), 'Authorization': 'Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJmb28iOiJiYXIifQ.UIZchxQD36xuhacrJF9HQ5SIUxH5HBiv9noESAacsxU', 'Content-Type': 'application/json'}, params=None)
         self.assertEqual(self.mock_http.get.call_count, 1)
     
     def test_get_file_async(self):
@@ -422,7 +422,7 @@ class TestSignatureAsync(BaseTest):
         
         self.assertIsNotNone(data)
         #self.assertEqual()
-        self.mock_http.get.assert_called_once_with('http://localhost:5000/signature/documents/1/files', headers={'X-Idfy-SDK': 'Python {}'.format(version), 'Authorization': 'Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJmb28iOiJiYXIifQ.UIZchxQD36xuhacrJF9HQ5SIUxH5HBiv9noESAacsxU', 'Content-Type': 'application/json'}, params='2')
+        self.mock_http.get.assert_called_once_with('{}/signature/documents/1/files'.format(self.base_url), headers={'X-Idfy-SDK': 'Python {}'.format(version), 'Authorization': 'Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJmb28iOiJiYXIifQ.UIZchxQD36xuhacrJF9HQ5SIUxH5HBiv9noESAacsxU', 'Content-Type': 'application/json'}, params='2')
         self.assertEqual(self.mock_http.get.call_count, 1)
 
     def test_get_file_for_signer_async(self):
@@ -433,7 +433,7 @@ class TestSignatureAsync(BaseTest):
         
         self.assertIsNotNone(data)
         #self.assertEqual()
-        self.mock_http.get.assert_called_once_with('http://localhost:5000/signature/documents/1/files/signers/2', headers={'X-Idfy-SDK': 'Python {}'.format(version), 'Authorization': 'Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJmb28iOiJiYXIifQ.UIZchxQD36xuhacrJF9HQ5SIUxH5HBiv9noESAacsxU', 'Content-Type': 'application/json'}, params='3')
+        self.mock_http.get.assert_called_once_with('{}/signature/documents/1/files/signers/2'.format(self.base_url), headers={'X-Idfy-SDK': 'Python {}'.format(version), 'Authorization': 'Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJmb28iOiJiYXIifQ.UIZchxQD36xuhacrJF9HQ5SIUxH5HBiv9noESAacsxU', 'Content-Type': 'application/json'}, params='3')
         self.assertEqual(self.mock_http.get.call_count, 1)
     
     def test_get_attachment_file_async(self):
@@ -444,7 +444,7 @@ class TestSignatureAsync(BaseTest):
         
         self.assertIsNotNone(data)
         #self.assertEqual()
-        self.mock_http.get.assert_called_once_with('http://localhost:5000/signature/documents/1/files/attachments/2', headers={'X-Idfy-SDK': 'Python {}'.format(version), 'Authorization': 'Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJmb28iOiJiYXIifQ.UIZchxQD36xuhacrJF9HQ5SIUxH5HBiv9noESAacsxU', 'Content-Type': 'application/json'}, params='3')
+        self.mock_http.get.assert_called_once_with('{}/signature/documents/1/files/attachments/2'.format(self.base_url), headers={'X-Idfy-SDK': 'Python {}'.format(version), 'Authorization': 'Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJmb28iOiJiYXIifQ.UIZchxQD36xuhacrJF9HQ5SIUxH5HBiv9noESAacsxU', 'Content-Type': 'application/json'}, params='3')
         self.assertEqual(self.mock_http.get.call_count, 1)
     
     def test_get_attachment_file_for_signer_async(self):
@@ -455,7 +455,7 @@ class TestSignatureAsync(BaseTest):
         
         self.assertIsNotNone(data)
         #self.assertEqual()
-        self.mock_http.get.assert_called_once_with('http://localhost:5000/signature/documents/1/files/attachments/2/signers/3', headers={'X-Idfy-SDK': 'Python {}'.format(version), 'Authorization': 'Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJmb28iOiJiYXIifQ.UIZchxQD36xuhacrJF9HQ5SIUxH5HBiv9noESAacsxU', 'Content-Type': 'application/json'}, params='4')
+        self.mock_http.get.assert_called_once_with('{}/signature/documents/1/files/attachments/2/signers/3'.format(self.base_url), headers={'X-Idfy-SDK': 'Python {}'.format(version), 'Authorization': 'Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJmb28iOiJiYXIifQ.UIZchxQD36xuhacrJF9HQ5SIUxH5HBiv9noESAacsxU', 'Content-Type': 'application/json'}, params='4')
         self.assertEqual(self.mock_http.get.call_count, 1)
     
     def test_list_notifications_async(self):
@@ -466,7 +466,7 @@ class TestSignatureAsync(BaseTest):
         
         self.assertIsNotNone(data)
         #self.assertEqual()
-        self.mock_http.get.assert_called_once_with('http://localhost:5000/signature/documents/1/notifications', headers={'X-Idfy-SDK': 'Python {}'.format(version), 'Authorization': 'Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJmb28iOiJiYXIifQ.UIZchxQD36xuhacrJF9HQ5SIUxH5HBiv9noESAacsxU', 'Content-Type': 'application/json'}, params=None)
+        self.mock_http.get.assert_called_once_with('{}/signature/documents/1/notifications'.format(self.base_url), headers={'X-Idfy-SDK': 'Python {}'.format(version), 'Authorization': 'Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJmb28iOiJiYXIifQ.UIZchxQD36xuhacrJF9HQ5SIUxH5HBiv9noESAacsxU', 'Content-Type': 'application/json'}, params=None)
         self.assertEqual(self.mock_http.get.call_count, 1)
 
     def test_send_reminders_async(self):
@@ -477,7 +477,7 @@ class TestSignatureAsync(BaseTest):
         
         self.assertIsNotNone(data)
         #self.assertEqual()
-        self.mock_http.post.assert_called_once_with('http://localhost:5000/signature/documents/1/notifications/reminder', auth=None, data='{"unit": "test"}', headers={'X-Idfy-SDK': 'Python {}'.format(version), 'Authorization': 'Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJmb28iOiJiYXIifQ.UIZchxQD36xuhacrJF9HQ5SIUxH5HBiv9noESAacsxU', 'Content-Type': 'application/json'}, params=None)
+        self.mock_http.post.assert_called_once_with('{}/signature/documents/1/notifications/reminder'.format(self.base_url), auth=None, data='{"unit": "test"}', headers={'X-Idfy-SDK': 'Python {}'.format(version), 'Authorization': 'Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJmb28iOiJiYXIifQ.UIZchxQD36xuhacrJF9HQ5SIUxH5HBiv9noESAacsxU', 'Content-Type': 'application/json'}, params=None)
         self.assertEqual(self.mock_http.post.call_count, 1)
     
     def test_list_themes_async(self):
@@ -488,7 +488,7 @@ class TestSignatureAsync(BaseTest):
         
         self.assertIsNotNone(data)
         #self.assertEqual()
-        self.mock_http.get.assert_called_once_with('http://localhost:5000/signature/themes/list/themes', headers={'X-Idfy-SDK': 'Python {}'.format(version), 'Authorization': 'Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJmb28iOiJiYXIifQ.UIZchxQD36xuhacrJF9HQ5SIUxH5HBiv9noESAacsxU', 'Content-Type': 'application/json'}, params=None)
+        self.mock_http.get.assert_called_once_with('{}/signature/themes/list/themes'.format(self.base_url), headers={'X-Idfy-SDK': 'Python {}'.format(version), 'Authorization': 'Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJmb28iOiJiYXIifQ.UIZchxQD36xuhacrJF9HQ5SIUxH5HBiv9noESAacsxU', 'Content-Type': 'application/json'}, params=None)
         self.assertEqual(self.mock_http.get.call_count, 1)
     
     def test_list_spinners_async(self):
@@ -499,7 +499,7 @@ class TestSignatureAsync(BaseTest):
         
         self.assertIsNotNone(data)
         #self.assertEqual()
-        self.mock_http.get.assert_called_once_with('http://localhost:5000/signature/themes/list/spinners', headers={'X-Idfy-SDK': 'Python {}'.format(version), 'Authorization': 'Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJmb28iOiJiYXIifQ.UIZchxQD36xuhacrJF9HQ5SIUxH5HBiv9noESAacsxU', 'Content-Type': 'application/json'}, params=None)
+        self.mock_http.get.assert_called_once_with('{}/signature/themes/list/spinners'.format(self.base_url), headers={'X-Idfy-SDK': 'Python {}'.format(version), 'Authorization': 'Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJmb28iOiJiYXIifQ.UIZchxQD36xuhacrJF9HQ5SIUxH5HBiv9noESAacsxU', 'Content-Type': 'application/json'}, params=None)
         self.assertEqual(self.mock_http.get.call_count, 1)
 
 #Provide CLI to the test script.

--- a/test/test_services/test_validation.py
+++ b/test/test_services/test_validation.py
@@ -18,7 +18,7 @@ class TestValidation(BaseTest):
 
         self.assertIsNotNone(data)
         #self.AssertEqual()
-        self.mock_http.post.assert_called_once_with('http://localhost:5000/validation/no/bankid/validate', auth=None, data='{"unit": "test"}', headers={'X-Idfy-SDK': 'Python {}'.format(version), 'Authorization': 'Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJmb28iOiJiYXIifQ.UIZchxQD36xuhacrJF9HQ5SIUxH5HBiv9noESAacsxU', 'Content-Type': 'application/json'}, params=None)
+        self.mock_http.post.assert_called_once_with('{}/validation/no/bankid/validate'.format(self.base_url), auth=None, data='{"unit": "test"}', headers={'X-Idfy-SDK': 'Python {}'.format(version), 'Authorization': 'Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJmb28iOiJiYXIifQ.UIZchxQD36xuhacrJF9HQ5SIUxH5HBiv9noESAacsxU', 'Content-Type': 'application/json'}, params=None)
 
 
     def test_parse_and_validate_sdo(self):
@@ -26,7 +26,7 @@ class TestValidation(BaseTest):
 
         self.assertIsNotNone(data)
         #self.AssertEqual()
-        self.mock_http.post.assert_called_once_with('http://localhost:5000/validation/no/bankid/parse', auth=None, data='{"unit": "test"}', headers={'X-Idfy-SDK': 'Python {}'.format(version), 'Authorization': 'Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJmb28iOiJiYXIifQ.UIZchxQD36xuhacrJF9HQ5SIUxH5HBiv9noESAacsxU', 'Content-Type': 'application/json'}, params=None)
+        self.mock_http.post.assert_called_once_with('{}/validation/no/bankid/parse'.format(self.base_url), auth=None, data='{"unit": "test"}', headers={'X-Idfy-SDK': 'Python {}'.format(version), 'Authorization': 'Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJmb28iOiJiYXIifQ.UIZchxQD36xuhacrJF9HQ5SIUxH5HBiv9noESAacsxU', 'Content-Type': 'application/json'}, params=None)
 
 
 class TestValidationAsync(BaseTest):
@@ -49,7 +49,7 @@ class TestValidationAsync(BaseTest):
         data = self.loop.run_until_complete(func())
             
         self.assertIsNotNone(data)
-        self.mock_http.post.assert_called_once_with('http://localhost:5000/validation/no/bankid/validate', auth=None, data='{"unit": "test"}', headers={'X-Idfy-SDK': 'Python {}'.format(version), 'Authorization': 'Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJmb28iOiJiYXIifQ.UIZchxQD36xuhacrJF9HQ5SIUxH5HBiv9noESAacsxU', 'Content-Type': 'application/json'}, params=None)
+        self.mock_http.post.assert_called_once_with('{}/validation/no/bankid/validate'.format(self.base_url), auth=None, data='{"unit": "test"}', headers={'X-Idfy-SDK': 'Python {}'.format(version), 'Authorization': 'Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJmb28iOiJiYXIifQ.UIZchxQD36xuhacrJF9HQ5SIUxH5HBiv9noESAacsxU', 'Content-Type': 'application/json'}, params=None)
     
     def test_parse_and_validate_sdo_async(self):
         async def func():
@@ -57,4 +57,4 @@ class TestValidationAsync(BaseTest):
         data = self.loop.run_until_complete(func())
         
         self.assertIsNotNone(data)
-        self.mock_http.post.assert_called_once_with('http://localhost:5000/validation/no/bankid/parse', auth=None, data='{"unit": "test"}', headers={'X-Idfy-SDK': 'Python {}'.format(version), 'Authorization': 'Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJmb28iOiJiYXIifQ.UIZchxQD36xuhacrJF9HQ5SIUxH5HBiv9noESAacsxU', 'Content-Type': 'application/json'}, params=None)
+        self.mock_http.post.assert_called_once_with('{}/validation/no/bankid/parse'.format(self.base_url), auth=None, data='{"unit": "test"}', headers={'X-Idfy-SDK': 'Python {}'.format(version), 'Authorization': 'Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJmb28iOiJiYXIifQ.UIZchxQD36xuhacrJF9HQ5SIUxH5HBiv9noESAacsxU', 'Content-Type': 'application/json'}, params=None)


### PR DESCRIPTION
Instead of hardcoding the url for the mockserver use the base_url which allows you to set the url and port your self.